### PR TITLE
PIA-1291: Make wireguard the default option

### DIFF
--- a/Sources/PIALibrary/Client+Configuration.swift
+++ b/Sources/PIALibrary/Client+Configuration.swift
@@ -225,7 +225,12 @@ extension Client {
             enablesServerPings = false
             minPingInterval = 120000
 
+            availableVPNProfiles = []
+
+            #if os(tvOS)
             availableVPNProfiles = [IKEv2Profile()]
+            #endif
+
             vpnProfileName = "Private Internet Access"
             vpnReconnectionDelay = 2000
             

--- a/Sources/PIALibrary/Client+Preferences.swift
+++ b/Sources/PIALibrary/Client+Preferences.swift
@@ -307,6 +307,12 @@ extension Client {
             allMaps[vpnType] = customConfiguration.serialized()
             accessedDatabase.plain.vpnCustomConfigurationMaps = allMaps
         }
+
+        #if os(iOS)
+        public func setVpnTypeToWireguard() {
+            self.vpnType = PIAWGTunnelProfile.vpnType
+        }
+        #endif
         
         /// The `String` array of available WiFi networks
         public fileprivate(set) var availableNetworks: [String] {
@@ -399,6 +405,16 @@ extension Client {
                 accessedDatabase.plain.timeToConnectVPN = newValue
             }
         }
+
+        /// Store a bool that represents whether we already attempted to migrate to wireguard
+        public var wireguardMigrationPerformed: Bool {
+            get {
+                return accessedDatabase.plain.wireguardMigrationPerformed
+            }
+            set {
+                accessedDatabase.plain.wireguardMigrationPerformed = newValue
+            }
+        }
         
         /// Store a bool that represents the status of leak protection property
         public var leakProtection: Bool {
@@ -481,7 +497,15 @@ extension Client.Preferences {
             useWiFiProtection = true
             trustCellularData = false
             nmtMigrationSuccess = false
+
+            #if os(iOS)
+            vpnType = PIAWGTunnelProfile.vpnType
+            #endif
+
+            #if os(tvOS)
             vpnType = IKEv2Profile.vpnType
+            #endif
+
             vpnDisconnectsOnSleep = false
             vpnCustomConfigurations = [:]
             availableNetworks = []

--- a/Sources/PIALibrary/Persistence/PlainStore.swift
+++ b/Sources/PIALibrary/Persistence/PlainStore.swift
@@ -72,6 +72,8 @@ protocol PlainStore: class {
     var lastVPNConnectionAttempt: Double { get set }
     
     var timeToConnectVPN: Double { get set }
+
+    var wireguardMigrationPerformed: Bool { get set }
     
     var leakProtection: Bool { get set }
     

--- a/Sources/PIALibrary/Persistence/UserDefaultsStore.swift
+++ b/Sources/PIALibrary/Persistence/UserDefaultsStore.swift
@@ -106,6 +106,8 @@ class UserDefaultsStore: PlainStore, ConfigurationAccess {
         static let lastVPNConnectionAttempt = "lastVPNConnectionAttempt"
         
         static let timeToConnectVPN = "timeToConnectVPN"
+
+        static let wireguardMigrationPerformed = "WireguardMigrationPerformed"
         
         static let leakProtection = "LeakProtection"
         
@@ -439,6 +441,18 @@ class UserDefaultsStore: PlainStore, ConfigurationAccess {
         }
         set {
             backend.set(newValue, forKey: Entries.timeToConnectVPN)
+        }
+    }
+
+    var wireguardMigrationPerformed: Bool {
+        get {
+            if backend.object(forKey: Entries.wireguardMigrationPerformed) == nil {
+                backend.set(false, forKey: Entries.wireguardMigrationPerformed)
+            }
+            return backend.bool(forKey: Entries.wireguardMigrationPerformed)
+        }
+        set {
+            backend.set(newValue, forKey: Entries.wireguardMigrationPerformed)
         }
     }
     

--- a/Sources/PIALibrary/VPN/IKEv2Profile.swift
+++ b/Sources/PIALibrary/VPN/IKEv2Profile.swift
@@ -34,7 +34,7 @@ public class IKEv2Profile: NetworkExtensionProfile {
         return NEVPNManager.shared()
     }
     
-    init() {
+    public init() {
     }
     
     // MARK: VPNProfile

--- a/Sources/PIALibrary/VPN/PIATunnelProfile.swift
+++ b/Sources/PIALibrary/VPN/PIATunnelProfile.swift
@@ -75,6 +75,7 @@ public class PIATunnelProfile: NetworkExtensionProfile {
                 callback?(error)
                 return
             }
+
             self.doSave(vpn, withConfiguration: configuration, force: true) { (error) in
                 if let _ = error {
                     callback?(error)

--- a/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
+++ b/Sources/PIALibrary/VPN/PIAWGTunnelProfile.swift
@@ -152,6 +152,7 @@ public class PIAWGTunnelProfile: NetworkExtensionProfile {
                 callback?(error)
                 return
             }
+
             self.doSave(vpn, withConfiguration: configuration, force: true) { (error) in
                 if let _ = error {
                     callback?(error)


### PR DESCRIPTION
## Summary

It introduces the changes to make wireguard the default protocol on new installations and the logic to allow us to migrate to wireguard those on ikev2 with default settings.

## Sanity Testers
_Tests were performed with the application changes introduced [here](https://github.com/pia-foss/mobile-ios/pull/73)_

- [x] Clean install. Open app. Confirm wireguard is the selected protocol.
- [x] Install current production. Without changing any settings. Upgrade to this version. Confirm wireguard is the selected protocol.
- [x] Install current production. Change any ikev2 setting. Upgrade to this version. Confirm ikev2 is the selected protocol.
- [x] After the above. Change back to ikev2 defaults. Kill process. Open app. Confirm ikev2 is the selected protocol.
- [x] After the above. Reset settings. Confirm wireguard is the selected protocol.