### PR TITLE
PIA-1544: Add tvOS token to Client in order to keep it in memory

### DIFF
--- a/Sources/PIALibrary/Client+Configuration.swift
+++ b/Sources/PIALibrary/Client+Configuration.swift
@@ -178,6 +178,9 @@ extension Client {
 
         /// Enabled features
         public var featureFlags: [String]
+        
+        /// tvOS token to bind with api token in order to Sign in on PIA Apple TV
+        public var tvOSBindToken: String?
 
         // MARK: Initialization
         


### PR DESCRIPTION
**Summary**
This PR adds the tvOS QR Sign in token to `Client`