### PR TITLE
PIA-1822: [Account migration] Get and save auth tokens from the Keychain store

### DIFF
--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -1,0 +1,21 @@
+
+import Foundation
+
+public class AccountFactory {
+  
+    public static func makeAPITokenUseCase() -> APITokenUseCaseType {
+        APITokenUseCase(keychainStore: makeSecureStore(), tokenSerializer: makeAuthTokenSerializer())
+    }
+    
+    public static func makeVpnTokenUseCase() -> VpnTokenUseCaseType {
+        VpnTokenUseCase(keychainStore: makeSecureStore(), tokenSerializer: makeAuthTokenSerializer())
+    }
+    
+    static func makeSecureStore() -> SecureStore {
+        KeychainStore(team: Client.Configuration.teamId, group: Client.Configuration.appGroup)
+    }
+    
+    static func makeAuthTokenSerializer() -> AuthTokenSerializerType {
+        AuthTokenSerializer()
+    }
+}

--- a/Sources/PIALibrary/Account/Domain/AuthTokenSerializer.swift
+++ b/Sources/PIALibrary/Account/Domain/AuthTokenSerializer.swift
@@ -1,0 +1,42 @@
+
+
+import Foundation
+
+protocol AuthTokenSerializerType {
+    func decodeAPIToken(from data: Data) -> APIToken?
+    func decodeVpnToken(from data: Data) -> VpnToken?
+    func encode(apiToken: APIToken) -> String?
+    func encode(vpnToken: VpnToken) -> String?
+    
+}
+
+class AuthTokenSerializer: AuthTokenSerializerType {
+    private let jsonDecoder = JSONDecoder()
+    private let jsonEncoder = JSONEncoder()
+    
+    init() {
+        jsonDecoder.dateDecodingStrategy = .iso8601
+        jsonEncoder.dateEncodingStrategy = .iso8601
+    }
+    
+    func decodeAPIToken(from data: Data) -> APIToken? {
+        try? jsonDecoder.decode(APIToken.self, from: data)
+    }
+    
+    func decodeVpnToken(from data: Data) -> VpnToken? {
+        try? jsonDecoder.decode(VpnToken.self, from: data)
+    }
+    
+    
+    func encode(apiToken: APIToken) -> String? {
+        guard let jsonData = try? jsonEncoder.encode(apiToken) else { return nil }
+        return String(data: jsonData, encoding: .utf8)
+    }
+    
+    func encode(vpnToken: VpnToken) -> String? {
+        guard let jsonData = try? jsonEncoder.encode(vpnToken) else { return nil }
+        return String(data: jsonData, encoding: .utf8)
+    }
+    
+}
+

--- a/Sources/PIALibrary/Account/Domain/Entities/APIToken.swift
+++ b/Sources/PIALibrary/Account/Domain/Entities/APIToken.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+
+
+public struct APIToken: Codable {
+    let token: String
+    let expiration: Date
+    
+    enum CodingKeys: String, CodingKey {
+        case token = "api_token"
+        case expiration = "expires_at"
+    }
+    
+    var isExpired: Bool {
+        expiration.timeIntervalSinceNow.sign == .minus
+    }
+}
+
+

--- a/Sources/PIALibrary/Account/Domain/Entities/VpnToken.swift
+++ b/Sources/PIALibrary/Account/Domain/Entities/VpnToken.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+
+public struct VpnToken: Codable {
+    let username: String
+    let password: String
+    let expiration: Date
+    
+    enum CodingKeys: String, CodingKey {
+        case username = "vpn_secret1"
+        case password = "vpn_secret2"
+        case expiration = "expires_at"
+    }
+    
+    var isExpired: Bool {
+        expiration.timeIntervalSinceNow.sign == .minus
+    }
+}
+

--- a/Sources/PIALibrary/Account/Domain/UseCases/APITokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/APITokenUseCase.swift
@@ -1,0 +1,41 @@
+
+import Foundation
+
+public protocol APITokenUseCaseType {
+    typealias Completion = (() -> Void)
+    func getAPIToken() -> APIToken?
+    func refreshAPIToken(completion: APITokenUseCaseType.Completion)
+}
+
+class APITokenUseCase: APITokenUseCaseType {
+    
+    private let apiTokenKey = "API_TOKEN_KEY"
+    
+    let keychainStore: SecureStore
+    let tokenSerializer: AuthTokenSerializerType
+    
+    init(keychainStore: SecureStore, tokenSerializer: AuthTokenSerializerType) {
+        self.keychainStore = keychainStore
+        self.tokenSerializer = tokenSerializer
+    }
+    
+    
+    public func getAPIToken() -> APIToken? {
+        guard let tokenDataString = keychainStore.token(for: apiTokenKey),
+              let tokenData = tokenDataString.data(using: .utf8) else { return nil }
+        return tokenSerializer.decodeAPIToken(from: tokenData)
+    }
+    
+    public func refreshAPIToken(completion: () -> Void) {
+        // TODO: Implement me
+        // 1. Call API to refresh API Token
+        // 2. Save refreshed token in the keychain
+    }
+    
+    func save(apiToken: APIToken) {
+        guard let encodedToken = tokenSerializer.encode(apiToken: apiToken) else { return }
+        keychainStore.setPassword(encodedToken, for: apiTokenKey)
+    }
+    
+    
+}

--- a/Sources/PIALibrary/Account/Domain/UseCases/VpnTokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/VpnTokenUseCase.swift
@@ -1,0 +1,40 @@
+
+import Foundation
+
+public protocol VpnTokenUseCaseType {
+    typealias Completion = (() -> Void)
+    func getVpnToken() -> VpnToken?
+    func refreshVpnToken(completion: VpnTokenUseCaseType.Completion)
+}
+
+class VpnTokenUseCase: VpnTokenUseCaseType {
+    
+    private let vpnTokenKey = "VPN_TOKEN_KEY"
+    
+    let keychainStore: SecureStore
+    let tokenSerializer: AuthTokenSerializerType
+    
+    init(keychainStore: SecureStore, tokenSerializer: AuthTokenSerializerType) {
+        self.keychainStore = keychainStore
+        self.tokenSerializer = tokenSerializer
+    }
+    
+    public func getVpnToken() -> VpnToken? {
+        guard let tokenDataString = keychainStore.token(for: vpnTokenKey),
+              let tokenData = tokenDataString.data(using: .utf8) else { return nil }
+        return tokenSerializer.decodeVpnToken(from: tokenData)
+    }
+    
+    public func refreshVpnToken(completion: () -> Void) {
+        // TODO: Implement me
+        // 1. Call API to refresh Vpn Token
+        // 2. Save refreshed token in the keychain
+    }
+    
+    func save(vpnToken: VpnToken) {
+        guard let encodedToken = tokenSerializer.encode(vpnToken: vpnToken) else { return }
+        keychainStore.setPassword(encodedToken, for: vpnTokenKey)
+    }
+    
+    
+}

--- a/Sources/PIALibrary/Persistence/KeychainStore.swift
+++ b/Sources/PIALibrary/Persistence/KeychainStore.swift
@@ -138,3 +138,13 @@ extension KeychainStore {
         return try? backend.passwordReference(for: dip)
     }
 }
+
+extension KeychainStore {
+    func setTokenData(_ tokenData: Data, for tokenKey: String) {
+        do {
+            try backend.setTokenData(tokenData, for: tokenKey)
+        } catch {
+            NSLog("KeychainStore: error setting token data: \(error)")
+        }
+    }
+}

--- a/Sources/PIALibrary/Persistence/SecureStore.swift
+++ b/Sources/PIALibrary/Persistence/SecureStore.swift
@@ -39,6 +39,9 @@ protocol SecureStore: class {
     func passwordReference(for username: String) -> Data?
 
     func token(for username: String) -> String?
+    
+    // TODO: This is not necessary, we can probably use setPassword(_ password: String?, for username: String)
+    func setTokenData(_ tokenData: Data, for tokenKey: String)
 
     func clearToken(for username: String)
     

--- a/Sources/PIALibrary/Util/Keychain.swift
+++ b/Sources/PIALibrary/Util/Keychain.swift
@@ -575,3 +575,27 @@ extension Keychain {
         return (status == errSecSuccess)
     }
 }
+
+
+// MARK: - API and Vpn Tokens updates
+
+extension Keychain {
+    
+    // TODO: This is not necessary, we can probably use setPassword(_ password: String?, for username: String)
+    func setTokenData(_ tokenData: Data, for tokenKey: String) throws {
+        
+        removeToken(for: tokenKey)
+        
+        var query = [String: Any]()
+        setScope(query: &query)
+        query[kSecClass as String] = kSecClassGenericPassword
+        query[kSecAttrAccount as String] = tokenKey
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        query[kSecValueData as String] = tokenData
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard (status == errSecSuccess) else {
+            throw KeychainError.add
+        }
+    }
+}

--- a/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -135,6 +135,8 @@ class PIAWebServices: WebServices, ConfigurationAccess {
      The token to use for api authentication.
      */
     var apiToken: String? {
+        let keychain = Keychain()
+        let token = try? keychain.token(for: "API_TOKEN_KEY")
         return self.accountAPI.apiToken()
     }
 

--- a/Tests/PIALibrary.xctestplan
+++ b/Tests/PIALibrary.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "005BA9AC-E352-4B79-B975-5B326E621F19",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "AccountInfoTests",
+        "AccountTests",
+        "DIPTokenKeychainTests",
+        "EndpointManagerTests",
+        "ProductTests"
+      ],
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "PIALibraryTests",
+        "name" : "PIALibraryTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/PIALibraryTests/AuthTokenSerializerTests.swift
+++ b/Tests/PIALibraryTests/AuthTokenSerializerTests.swift
@@ -1,0 +1,128 @@
+
+import Foundation
+import XCTest
+@testable import PIALibrary
+
+class AuthTokenSerializerTests: XCTestCase {
+    
+    class Fixture {
+        let validApiTokenJsonString = "{\"api_token\":\"some_api_token\",\"expires_at\":\"2034-08-11T00:00:00Z\"}"
+        let expiredApiTokenJsonString = "{\"api_token\":\"some_api_token\",\"expires_at\":\"2023-08-11T00:00:00Z\"}"
+        let validVpnTokenJsonString = "{\"vpn_secret1\":\"vpn_token_username\",\"vpn_secret2\":\"vpn_token_password\",\"expires_at\":\"2034-08-08T00:00:00Z\"}"
+        let expiredVpnTokenJsonString = "{\"vpn_secret1\":\"vpn_token_username\",\"vpn_secret2\":\"vpn_token_password\",\"expires_at\":\"2023-06-08T00:00:00Z\"}"
+        
+        let apiToken = APIToken(token: "other_api_token", expiration: Date.init(timeIntervalSinceNow: 1000))
+        
+        let vpnToken = VpnToken(username: "other_vpn_token_username", password: "other_vpn_token_password", expiration: Date.init(timeIntervalSinceNow: 1000))
+        
+    }
+
+    var sut: AuthTokenSerializer!
+    var fixture: Fixture!
+    
+    override func setUp() {
+        fixture = Fixture()
+        sut = AuthTokenSerializer()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+
+    func testDecodeValidAPIToken() {
+        // GIVEN some valid api token Data
+        let apiTokenData = fixture.validApiTokenJsonString.data(using: .utf8)!
+        
+        // WHEN decoding the Data
+        let decodedAPIToken = sut.decodeAPIToken(from: apiTokenData)!
+
+        // THEN the decoded api value is 'some_api_token'
+        XCTAssertEqual(decodedAPIToken.token, "some_api_token")
+        // AND the decoded API token is NOT expired
+        XCTAssertFalse(decodedAPIToken.isExpired)
+    }
+    
+    func testDecodeExpiredAPIToken() {
+        // GIVEN an expired api token Data
+        let apiTokenData = fixture.expiredApiTokenJsonString.data(using: .utf8)!
+        
+        // WHEN decoding the Data
+        let decodedAPIToken = sut.decodeAPIToken(from: apiTokenData)!
+
+        
+        // THEN the decoded api value is 'some_api_token'
+        XCTAssertEqual(decodedAPIToken.token, "some_api_token")
+        // AND the decoded API token is expired
+        XCTAssertTrue(decodedAPIToken.isExpired)
+    
+    }
+    
+    func testDecodeValidVpnToken() {
+        // GIVEN some valid vpn token Data
+        let tokenData = fixture.validVpnTokenJsonString.data(using: .utf8)!
+        
+        // WHEN decoding the Data
+        let decodedVpnToken = sut.decodeVpnToken(from: tokenData)!
+
+        // THEN the decoded values are
+        XCTAssertEqual(decodedVpnToken.username, "vpn_token_username")
+        XCTAssertEqual(decodedVpnToken.password, "vpn_token_password")
+        // AND the decoded token is NOT expired
+        XCTAssertFalse(decodedVpnToken.isExpired)
+    }
+    
+    func testDecodeExpiredVpnToken() {
+        // GIVEN an expired vpn token Data
+        let tokenData = fixture.expiredVpnTokenJsonString.data(using: .utf8)!
+        
+        // WHEN decoding the Data
+        let decodedVpnToken = sut.decodeVpnToken(from: tokenData)!
+
+        // THEN the decoded values are
+        XCTAssertEqual(decodedVpnToken.username, "vpn_token_username")
+        XCTAssertEqual(decodedVpnToken.password, "vpn_token_password")
+        // AND the decoded token is expired
+        XCTAssertTrue(decodedVpnToken.isExpired)
+    
+    }
+    
+    func testEncodeVpnToken() {
+        // WHEN encoding a valid Vpn Token into a JSON string
+        let encodedTokenString = sut.encode(vpnToken: fixture.vpnToken)
+        
+        let expirationDate = fixture.vpnToken.expiration
+        let dateFormatter = ISO8601DateFormatter()
+        let expirationDateString = dateFormatter.string(from: expirationDate)
+        
+        let expirationJsonEntry = "\"expires_at\":\"\(expirationDateString)\""
+        let usernameJsonEntry = "\"vpn_secret1\":\"other_vpn_token_username\""
+        let passwordJsonEntry = "\"vpn_secret2\":\"other_vpn_token_password\""
+        
+        // THEN the JSON strng contains the following entries
+        XCTAssertTrue(encodedTokenString!.contains(expirationJsonEntry))
+        XCTAssertTrue(encodedTokenString!.contains(usernameJsonEntry))
+        XCTAssertTrue(encodedTokenString!.contains(passwordJsonEntry))
+
+    }
+    
+    func testEncodeApiToken() {
+        // WHEN encoding a valid Api Token into a JSON string
+        let encodedTokenString = sut.encode(apiToken: fixture.apiToken)
+        
+        let expirationDate = fixture.apiToken.expiration
+        let dateFormatter = ISO8601DateFormatter()
+        let expirationDateString = dateFormatter.string(from: expirationDate)
+        
+        let expirationJsonEntry = "\"expires_at\":\"\(expirationDateString)\""
+        let apiTokenJsonEntry = "\"api_token\":\"other_api_token\""
+        
+        // THEN the JSON strng contains the following entries
+        XCTAssertTrue(encodedTokenString!.contains(expirationJsonEntry))
+        XCTAssertTrue(encodedTokenString!.contains(apiTokenJsonEntry))
+
+
+    }
+    
+}


### PR DESCRIPTION
- Get previously stored API token and Vpn Token from the keychain
- Handle data serialization when retrieving the tokens from the Keychain and when updating the tokens in the keychain
- Added unit tests to tokens serialization

NOTE: Calling the API to refresh the tokens will be handled in the next PR