### PR TITLE
PIA-1882: Refresh Auth tokens if needed on every request

### DIFF
--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -12,13 +12,16 @@ public class AccountFactory {
         
     }
     
-    
     static func makeAPITokenProvider() -> APITokenProviderType {
         APITokenProvider(keychainStore: makeSecureStore(), tokenSerializer: makeAuthTokenSerializer())
     }
     
     static func makeVpnTokenProvider() -> VpnTokenProviderType {
         VpnTokenProvider(keychainStore: makeSecureStore(), tokenSerializer: makeAuthTokenSerializer())
+    }
+    
+    static func makeRefreshAuthTokensChecker() -> RefreshAuthTokensCheckerType {
+        RefreshAuthTokensChecker(apiTokenProvider: makeAPITokenProvider(), vpnTokenProvier: makeVpnTokenProvider(), refreshAPITokenUseCase: makeRefreshAPITokenUseCase(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
     }
 }
 

--- a/Sources/PIALibrary/Account/Data/APITokenProvider.swift
+++ b/Sources/PIALibrary/Account/Data/APITokenProvider.swift
@@ -30,7 +30,7 @@ class APITokenProvider: APITokenProviderType {
     
     func saveAPIToken(from data: Data) throws {
         guard let apiToken = tokenSerializer.decodeAPIToken(from: data) else {
-            throw AccountAPIError.unableToDecodeAPIToken
+            throw NetworkRequestError.unableToDecodeAPIToken
         }
         
         save(apiToken: apiToken)

--- a/Sources/PIALibrary/Account/Data/Networking/RefreshApiTokenRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/RefreshApiTokenRequestConfiguration.swift
@@ -3,9 +3,14 @@ import Foundation
 import NWHttpConnection
 
 struct RefreshApiTokenRequestConfiguration: NetworkRequestConfigurationType {
+    let networkRequestModule: NetworkRequestModule = .account
     let path: RequestAPI.Path = .refreshApiToken
     let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .post
     let inlcudeAuthHeaders: Bool = true
+    
+    // Refreshing the auth tokens is not needed before executing the refresh API token request
+    let refreshAuthTokensIfNeeded: Bool = false
+    
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
     let body: Data? = nil

--- a/Sources/PIALibrary/Account/Data/Networking/RefreshVpnTokenRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/RefreshVpnTokenRequestConfiguration.swift
@@ -3,9 +3,14 @@ import Foundation
 import NWHttpConnection
 
 struct RefreshVpnTokenRequestConfiguration: NetworkRequestConfigurationType {
+    let networkRequestModule: NetworkRequestModule = .account
     let path: RequestAPI.Path = .vpnToken
     let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .post
     let inlcudeAuthHeaders: Bool = true
+    
+    // Refreshing the auth tokens is not needed before executing the refresh Vpn token request
+    let refreshAuthTokensIfNeeded: Bool = false
+    
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
     let body: Data? = nil

--- a/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
+++ b/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
@@ -1,0 +1,110 @@
+
+import Foundation
+
+protocol RefreshAuthTokensCheckerType {
+    typealias Completion = ((NetworkRequestError?) -> Void)
+    func refreshIfNeeded(completion: @escaping Completion)
+}
+
+class RefreshAuthTokensChecker: RefreshAuthTokensCheckerType {
+    
+    let apiTokenProvider: APITokenProviderType
+    let vpnTokenProvier: VpnTokenProviderType
+    let refreshAPITokenUseCase: RefreshAPITokenUseCaseType
+    let refreshVpnTokenUseCase: RefreshVpnTokenUseCaseType
+    
+    // Number of days remaining before refreshing a token
+    private let daysUntilRefresh: Double = 30
+    
+    init(apiTokenProvider: APITokenProviderType, vpnTokenProvier: VpnTokenProviderType, refreshAPITokenUseCase: RefreshAPITokenUseCaseType, refreshVpnTokenUseCase: RefreshVpnTokenUseCaseType) {
+        self.apiTokenProvider = apiTokenProvider
+        self.vpnTokenProvier = vpnTokenProvier
+        self.refreshAPITokenUseCase = refreshAPITokenUseCase
+        self.refreshVpnTokenUseCase = refreshVpnTokenUseCase
+    }
+    
+    func refreshIfNeeded(completion: @escaping Completion) {
+        
+        switch (shouldRefreshApiToken(), shouldRefreshVpnToken()) {
+        case (true, true):
+            refreshBothTokens(with: completion)
+        case (true, false):
+            refreshApiToken(with: completion)
+        case(false, true):
+            refreshVpnToken(with: completion)
+        case(false, false):
+            completion(nil)
+        }
+    }
+    
+}
+
+// MARK: - Refresh tokens helpers
+
+private extension RefreshAuthTokensChecker {
+    
+    func refreshBothTokens(with completion: @escaping Completion) {
+        refreshAPITokenUseCase() { refreshApiTokenError in
+            if let refreshApiTokenError {
+                completion(refreshApiTokenError)
+            } else {
+                self.refreshVpnTokenUseCase() { refreshVpnTokenError in
+                    if let refreshVpnTokenError {
+                        completion(refreshVpnTokenError)
+                    } else {
+                        completion(nil)
+                    }
+                }
+            }
+        }
+    }
+    
+    func refreshApiToken(with completion: @escaping Completion) {
+        refreshAPITokenUseCase() { error in
+            self.handleRefreshResponse(with: error, completion: completion)
+        }
+    }
+    
+    func refreshVpnToken(with completion: @escaping Completion) {
+        refreshVpnTokenUseCase() { error in
+            self.handleRefreshResponse(with: error, completion: completion)
+        }
+    }
+    
+    func handleRefreshResponse(with error: NetworkRequestError?, completion: @escaping Completion) {
+        if let error {
+            completion(error)
+        } else {
+            completion(nil)
+        }
+    }
+}
+
+// MARK: - Refresh time intervals utils
+
+private extension RefreshAuthTokensChecker {
+    
+    func shouldRefreshApiToken() -> Bool {
+        guard let apiToken = apiTokenProvider.getAPIToken() else {
+             return true
+        }
+
+        return shouldRefresh(with: apiToken.expiresAt)
+    }
+    
+    func shouldRefreshVpnToken() -> Bool {
+        guard let vpnToken = vpnTokenProvier.getVpnToken() else {
+             return true
+        }
+        
+        return shouldRefresh(with: vpnToken.expiresAt)
+    }
+    
+    
+    func shouldRefresh(with expiration: Date) -> Bool {
+        let daysUntilExpires = expiration.timeIntervalSinceNow.inDays()
+        
+        return daysUntilExpires < daysUntilRefresh
+    }
+    
+}

--- a/Sources/PIALibrary/Account/Data/VpnTokenProvider.swift
+++ b/Sources/PIALibrary/Account/Data/VpnTokenProvider.swift
@@ -31,7 +31,7 @@ class VpnTokenProvider: VpnTokenProviderType {
     
     func saveVpnToken(from data: Data) throws {
         guard let vpnToken = tokenSerializer.decodeVpnToken(from: data) else {
-            throw AccountAPIError.unableToDecodeVpnToken
+            throw NetworkRequestError.unableToDecodeVpnToken
         }
         
         save(vpnToken: vpnToken)

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
@@ -3,7 +3,7 @@ import Foundation
 import NWHttpConnection
 
 public protocol RefreshAPITokenUseCaseType {
-    typealias Completion = ((AccountAPIError?) -> Void)
+    typealias Completion = ((NetworkRequestError?) -> Void)
     func callAsFunction(completion: @escaping RefreshAPITokenUseCaseType.Completion)
 }
 
@@ -29,7 +29,7 @@ class RefreshAPITokenUseCase: RefreshAPITokenUseCaseType {
             } else if let dataResponse {
                 self.handleDataResponse(dataResponse, completion: completion)
             } else {
-                completion(AccountAPIError.allConnectionAttemptsFailed)
+                completion(NetworkRequestError.allConnectionAttemptsFailed)
             }
         }
         
@@ -43,7 +43,7 @@ private extension RefreshAPITokenUseCase {
     private func handleDataResponse(_ dataResponse: NetworkRequestResponseType, completion: @escaping RefreshVpnTokenUseCaseType.Completion) {
         
         guard let dataResponseContent = dataResponse.data else {
-            completion(AccountAPIError.noDataContent)
+            completion(NetworkRequestError.noDataContent)
             return
         }
         
@@ -51,7 +51,7 @@ private extension RefreshAPITokenUseCase {
             try apiTokenProvider.saveAPIToken(from: dataResponseContent)
             completion(nil)
         } catch {
-            completion(AccountAPIError.unableToSaveAPIToken)
+            completion(NetworkRequestError.unableToSaveAPIToken)
         }
         
     }

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public protocol RefreshVpnTokenUseCaseType {
-    typealias Completion = ((AccountAPIError?) -> Void)
+    typealias Completion = ((NetworkRequestError?) -> Void)
     func callAsFunction(completion: @escaping RefreshVpnTokenUseCaseType.Completion)
 }
 
@@ -30,7 +30,7 @@ class RefreshVpnTokenUseCase: RefreshVpnTokenUseCaseType {
             } else if let dataResponse {
                 self.handleDataResponse(dataResponse, completion: completion)
             } else {
-                completion(AccountAPIError.allConnectionAttemptsFailed)
+                completion(NetworkRequestError.allConnectionAttemptsFailed)
             }
             
         }
@@ -43,7 +43,7 @@ private extension RefreshVpnTokenUseCase {
     private func handleDataResponse(_ dataResponse: NetworkRequestResponseType, completion: @escaping RefreshVpnTokenUseCaseType.Completion) {
         
         guard let dataResponseContent = dataResponse.data else {
-            completion(AccountAPIError.noDataContent)
+            completion(NetworkRequestError.noDataContent)
             return
         }
         
@@ -51,7 +51,7 @@ private extension RefreshVpnTokenUseCase {
             try vpnTokenProvider.saveVpnToken(from: dataResponseContent)
             completion(nil)
         } catch {
-            completion(AccountAPIError.unableToSaveVpnToken)
+            completion(NetworkRequestError.unableToSaveVpnToken)
         }
         
     }

--- a/Sources/PIALibrary/Common/CompositionRoot/NetworkRequestFactory.swift
+++ b/Sources/PIALibrary/Common/CompositionRoot/NetworkRequestFactory.swift
@@ -11,7 +11,7 @@ public class NetworkRequestFactory {
 
 private extension NetworkRequestFactory {
     static var networkRequestClientShared: NetworkRequestClientType = {
-        NetworkRequestClient(networkConnectionRequestProvider: makeNetworkConnectionRequestProvider(), endpointManager: makeEndpointManager())
+        NetworkRequestClient(networkConnectionRequestProvider: makeNetworkConnectionRequestProvider(), endpointManager: makeEndpointManager(), refreshAuthTokensChecker: AccountFactory.makeRefreshAuthTokensChecker())
     }()
     
     static func makeEndpointManager() -> EndpointManagerType {

--- a/Sources/PIALibrary/Common/Data/Extensions/TimeInterval+Extensions.swift
+++ b/Sources/PIALibrary/Common/Data/Extensions/TimeInterval+Extensions.swift
@@ -1,0 +1,16 @@
+
+import Foundation
+
+extension TimeInterval {
+    func inMinutes() -> Double {
+        return (self / 60)
+    }
+    
+    func inHours() -> Double {
+        return (inMinutes() / 60)
+    }
+    
+    func inDays() -> Double {
+        return (inHours() / 24)
+    }
+}

--- a/Sources/PIALibrary/Common/Data/Networking/Entities/NetworkRequestError.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/Entities/NetworkRequestError.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-public enum AccountAPIError: Error, Equatable {
+public enum NetworkRequestError: Error, Equatable {
     case apiTokenNotFound
     case anchorCertificateNotFound
     case connectionError(message: String?)

--- a/Sources/PIALibrary/Common/Data/Networking/Interfaces/NetworkRequestConfigurationType.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/Interfaces/NetworkRequestConfigurationType.swift
@@ -2,10 +2,16 @@
 import Foundation
 import NWHttpConnection
 
+enum NetworkRequestModule {
+    case account
+}
+
 protocol NetworkRequestConfigurationType {
+    var networkRequestModule: NetworkRequestModule { get }
     var path: RequestAPI.Path { get }
     var httpMethod: NWConnectionHTTPMethod { get }
     var inlcudeAuthHeaders: Bool { get }
+    var refreshAuthTokensIfNeeded: Bool { get }
     var urlQueryParameters: [String: String]? { get }
     var responseDataType: NWDataResponseType { get }
     var body: Data? { get }

--- a/Tests/PIALibraryTests/Mocks/APITokenProviderMock.swift
+++ b/Tests/PIALibraryTests/Mocks/APITokenProviderMock.swift
@@ -1,0 +1,27 @@
+
+import Foundation
+@testable import PIALibrary
+
+class APITokenProviderMock: APITokenProviderType {
+    
+    var getAPITokenCalledAttempt = 0
+    var getAPITokenResult: APIToken?
+    func getAPIToken() -> APIToken? {
+        getAPITokenCalledAttempt += 1
+     return getAPITokenResult
+    }
+    
+    var saveAPITokenCalledAttempt = 0
+    var saveAPITokenCalledWithArg: APIToken?
+    func save(apiToken: APIToken) {
+        saveAPITokenCalledAttempt += 1
+        saveAPITokenCalledWithArg = apiToken
+    }
+    
+    var saveAPITokenFromDataCalledAttempt = 0
+    var saveAPITokenFromDataCalledWithArg: Data?
+    func saveAPIToken(from data: Data) throws {
+        saveAPITokenFromDataCalledAttempt += 1
+        saveAPITokenFromDataCalledWithArg = data
+    }
+}

--- a/Tests/PIALibraryTests/Mocks/NetworkRequestConfigurationMock.swift
+++ b/Tests/PIALibraryTests/Mocks/NetworkRequestConfigurationMock.swift
@@ -6,6 +6,10 @@ import NWHttpConnection
 
 struct NetworkRequestConfigurationMock: NetworkRequestConfigurationType {
     
+    var networkRequestModule: NetworkRequestModule = .account
+    var refreshAuthTokensIfNeeded: Bool = false
+    
+    
     var path: RequestAPI.Path = .vpnToken
     var httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .get
     var inlcudeAuthHeaders: Bool = true

--- a/Tests/PIALibraryTests/Mocks/RefreshAPITokenUseCaseMock.swift
+++ b/Tests/PIALibraryTests/Mocks/RefreshAPITokenUseCaseMock.swift
@@ -1,0 +1,13 @@
+
+import Foundation
+@testable import PIALibrary
+
+class RefreshAPITokenUseCaseMock: RefreshAPITokenUseCaseType {
+    var callAsFunctionCalledAttempt = 0
+    var completionError: NetworkRequestError?
+    
+    func callAsFunction(completion: @escaping ((NetworkRequestError?) -> Void)) {
+        callAsFunctionCalledAttempt += 1
+        completion(completionError)
+    }
+}

--- a/Tests/PIALibraryTests/Mocks/RefreshAuthTokensCheckerMock.swift
+++ b/Tests/PIALibraryTests/Mocks/RefreshAuthTokensCheckerMock.swift
@@ -1,0 +1,16 @@
+
+
+import Foundation
+@testable import PIALibrary
+
+class RefreshAuthTokensCheckerMock: RefreshAuthTokensCheckerType {
+    
+    var refreshIfNeededCalledAttempt = 0
+    var refreshIfNeededError: NetworkRequestError? = nil
+    func refreshIfNeeded(completion: @escaping Completion) {
+        refreshIfNeededCalledAttempt += 1
+        completion(refreshIfNeededError)
+    }
+    
+    
+}

--- a/Tests/PIALibraryTests/Mocks/RefreshVpnTokenUseCaseMock.swift
+++ b/Tests/PIALibraryTests/Mocks/RefreshVpnTokenUseCaseMock.swift
@@ -1,0 +1,15 @@
+
+import Foundation
+@testable import PIALibrary
+
+class RefreshVpnTokenUseCaseMock: RefreshVpnTokenUseCaseType {
+    
+    var callAsFunctionCalledAttempt = 0
+    var completionError: NetworkRequestError?
+    
+    func callAsFunction(completion: @escaping ((NetworkRequestError?) -> Void)) {
+        callAsFunctionCalledAttempt += 1
+        completion(completionError)
+    }
+}
+

--- a/Tests/PIALibraryTests/Mocks/VpnTokenProviderMock.swift
+++ b/Tests/PIALibraryTests/Mocks/VpnTokenProviderMock.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import PIALibrary
+
+class VpnTokenProviderMock: VpnTokenProviderType {
+    
+    var getVpnTokenCalledAttempt = 0
+    var getVpnTokenResult: VpnToken?
+    func getVpnToken() -> VpnToken? {
+        getVpnTokenCalledAttempt += 1
+     return getVpnTokenResult
+    }
+    
+    var saveVpnTokenCalledAttempt = 0
+    var saveVpnTokenCalledWithArg: VpnToken?
+    func save(vpnToken: VpnToken) {
+        saveVpnTokenCalledAttempt += 1
+        saveVpnTokenCalledWithArg = vpnToken
+    }
+    
+    var saveVpnTokenFromDataCalledAttempt = 0
+    var saveVpnTokenFromDataCalledWithArg: Data?
+    func saveVpnToken(from data: Data) throws {
+        saveVpnTokenFromDataCalledAttempt += 1
+        saveVpnTokenFromDataCalledWithArg = data
+    }
+}
+

--- a/Tests/PIALibraryTests/NetworkRequestClientTests.swift
+++ b/Tests/PIALibraryTests/NetworkRequestClientTests.swift
@@ -9,8 +9,9 @@ class NetworkRequestClientTests: XCTestCase {
        
         let networkConnectionRequestProviderMock = NetworkConnectionRequestProviderMock()
         let endpointManagerMock = EndpointManagerMock()
-        let configurationMock = NetworkRequestConfigurationMock()
+        var configurationMock = NetworkRequestConfigurationMock()
         let endpointMock = PinningEndpoint(host: "mock-endpoint")
+        let refreshAuthTokensCheckerMock = RefreshAuthTokensCheckerMock()
         
         init() {
         }
@@ -25,7 +26,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         func makeFailedConnectionWithErrorAndNoResponse() -> NWHttpConnectionMock {
             let failConnectionWithNoResponse = NWHttpConnectionMock()
-            failConnectionWithNoResponse.connectionError = NWHttpConnectionError.unknown(AccountAPIError.unknown)
+            failConnectionWithNoResponse.connectionError = NWHttpConnectionError.unknown(NetworkRequestError.unknown)
             failConnectionWithNoResponse.connectionResponse = nil
             return failConnectionWithNoResponse
             
@@ -72,12 +73,15 @@ class NetworkRequestClientTests: XCTestCase {
     }
     
     private func instantiateSut() {
-        sut = NetworkRequestClient(networkConnectionRequestProvider: fixture.networkConnectionRequestProviderMock, endpointManager: fixture.endpointManagerMock)
+        sut = NetworkRequestClient(networkConnectionRequestProvider: fixture.networkConnectionRequestProviderMock, endpointManager: fixture.endpointManagerMock, refreshAuthTokensChecker: fixture.refreshAuthTokensCheckerMock)
         
     }
     
-    func testMakeRequestWhenFirstConnectionSucceeds() {
-        // GIVEN that we have 2 connections and the first one succees
+    func testMakeSuccessfulRequest_WhenRefreshTokensEnalbed() {
+        // GIVEN that the network request config has refresh auth tokens enabled
+        fixture.configurationMock.refreshAuthTokensIfNeeded = true
+        
+        // AND GIVEN that we have 2 successfull connections
         let connection1 = fixture.makeSuccessConnection()
         let connection2 = fixture.makeSuccessConnection()
         
@@ -87,11 +91,17 @@ class NetworkRequestClientTests: XCTestCase {
         
         let expectation = expectation(description: "The request was executed")
         
-        var capturedError: AccountAPIError?
+        var capturedError: NetworkRequestError?
         var capturedResponse: NetworkRequestResponseType?
+        
+        // The refresh tokens call has no been executed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 0)
         
         // WHEN we execute the request
         sut.executeRequest(with: fixture.configurationMock) { error, dataResponse in
+            // THEN the call to refresh the tokens is executed
+            XCTAssertEqual(self.fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+            
             capturedError = error
             capturedResponse = dataResponse
             
@@ -100,7 +110,51 @@ class NetworkRequestClientTests: XCTestCase {
         
         wait(for: [expectation], timeout: 3)
         
-        // THEN only the first connection is executed
+        
+        // AND only the first connection is executed
+        XCTAssertEqual(connection1.connectCalledAttempt, 1)
+        XCTAssertEqual(connection2.connectCalledAttempt, 0)
+        
+        // AND No error is returned
+        XCTAssertNil(capturedError)
+        
+        // AND a sucessful response is returned
+        XCTAssertNotNil(capturedResponse)
+        XCTAssertEqual(capturedResponse!.statusCode!, 200)
+    }
+    
+    func testMakeSuccessfulRequest_AndRefreshTokenDisabled() {
+        // GIVEN that the network request config has refresh auth tokens disabled
+        fixture.configurationMock.refreshAuthTokensIfNeeded = false
+        
+        // AND GIVEN that we have 2 connections and the first one succees
+        let connection1 = fixture.makeSuccessConnection()
+        let connection2 = fixture.makeSuccessConnection()
+        
+        fixture.stubMakeConnections(connections: [connection1, connection2])
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "The request was executed")
+        
+        var capturedError: NetworkRequestError?
+        var capturedResponse: NetworkRequestResponseType?
+        
+        // WHEN we execute the request
+        sut.executeRequest(with: fixture.configurationMock) { error, dataResponse in
+            
+            capturedError = error
+            capturedResponse = dataResponse
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the call to refresh the tokens is NEVER executed
+        XCTAssertEqual(self.fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 0)
+        
+        // AND only the first connection is executed
         XCTAssertEqual(connection1.connectCalledAttempt, 1)
         XCTAssertEqual(connection2.connectCalledAttempt, 0)
         
@@ -123,7 +177,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         let expectation = expectation(description: "The request was executed")
         
-        var capturedError: AccountAPIError?
+        var capturedError: NetworkRequestError?
         var capturedResponse: NetworkRequestResponseType?
         
         // WHEN we execute the request
@@ -159,7 +213,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         let expectation = expectation(description: "The request was executed")
         
-        var capturedError: AccountAPIError?
+        var capturedError: NetworkRequestError?
         var capturedResponse: NetworkRequestResponseType?
         
         // WHEN we execute the request
@@ -178,7 +232,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         // AND an error is returned
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, AccountAPIError.allConnectionAttemptsFailed)
+        XCTAssertEqual(capturedError!, NetworkRequestError.allConnectionAttemptsFailed)
         
         // AND a response is not returned
         XCTAssertNil(capturedResponse)
@@ -196,7 +250,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         let expectation = expectation(description: "The request was executed")
         
-        var capturedError: AccountAPIError?
+        var capturedError: NetworkRequestError?
         var capturedResponse: NetworkRequestResponseType?
         
         // WHEN we execute the request
@@ -215,7 +269,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         // AND an error is returned
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, AccountAPIError.allConnectionAttemptsFailed)
+        XCTAssertEqual(capturedError!, NetworkRequestError.allConnectionAttemptsFailed)
         
         // AND a response is not returned
         XCTAssertNil(capturedResponse)

--- a/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
+++ b/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
@@ -1,0 +1,189 @@
+
+import XCTest
+@testable import PIALibrary
+
+class RefreshAuthTokensCheckerTests: XCTestCase {
+    class Fixture {
+        let apiTokenProviderMock = APITokenProviderMock()
+        let vpnTokenProviderMock = VpnTokenProviderMock()
+        let refreshAPITokenUseCaseMock = RefreshAPITokenUseCaseMock()
+        let refreshVpnTokenUseCaseMock = RefreshVpnTokenUseCaseMock()
+        
+        let expirationDateIn10Days = Calendar.current.date(byAdding: .day, value: 10, to: Date())!
+        let expirationDateIn31Days = Calendar.current.date(byAdding: .day, value: 31, to: Date())!
+        
+        func stubAPIToken(with expirationDate: Date) {
+            let apiToken = APIToken(apiToken: "some_api_token", expiresAt: expirationDate)
+            apiTokenProviderMock.getAPITokenResult = apiToken
+        }
+        
+        func stubVpnToken(with expirationDate: Date) {
+            let vpnToken = VpnToken(vpnUsernameToken: "token_username", vpnPasswordToken: "token_password", expiresAt: expirationDate)
+            vpnTokenProviderMock.getVpnTokenResult = vpnToken
+        }
+        
+        func stubRefreshAPIToken(with error: NetworkRequestError?) {
+            refreshAPITokenUseCaseMock.completionError = error
+        }
+        
+        func stubRefreshVpnToken(with error: NetworkRequestError?) {
+            refreshVpnTokenUseCaseMock.completionError = error
+        }
+        
+        
+    }
+    
+    var fixture: Fixture!
+    var sut: RefreshAuthTokensChecker!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = RefreshAuthTokensChecker(apiTokenProvider: fixture.apiTokenProviderMock, vpnTokenProvier: fixture.vpnTokenProviderMock, refreshAPITokenUseCase: fixture.refreshAPITokenUseCaseMock, refreshVpnTokenUseCase: fixture.refreshVpnTokenUseCaseMock)
+    }
+    
+    
+    func testRefreshTokensWithSuccess_WhenBothExpireIn10Days() {
+        // GIVEN that both the API token and Vpn token will expire in 10 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN both tokens are refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokensWithError_WhenBothExpireIn10Days() {
+        // GIVEN that both the API token and Vpn token will expire in 10 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+        
+        // AND GIVEN that refreshing the API token request fails
+        fixture.stubRefreshAPIToken(with: .apiTokenNotFound)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN only the request to refresh the api token is called
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    
+    func testRefreshTokens_WhenBothExpireInMoreThan30Days() {
+        // GIVEN that both the API token and Vpn token will expire in 31 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
+        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the tokens don't get refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokens_WhenAPITokenIsAboutExpiring() {
+        // GIVEN that the the API token expires in 10 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+        // AND that the the Vpn token expires in 31 days
+        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN Only the API token is refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokens_WhenVpnTokenIsAboutExpiring() {
+        // GIVEN that the the API token expires in 31 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
+        // AND that the the Vpn token expires in 10 days
+        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN Only the Vpn token is refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+}


### PR DESCRIPTION
- The Network client will make a call to check whether the auth tokens should be refreshed before performing a request if the configuration has the property `refreshAuthTokensIfNeeded` enabled -> this gives us the flexibility to execute requests with and without refreshing tokens

- The `RefreshAuthTokensChecker`  will check the expiration date of both the api and vpn tokens. And it will refresh them only if they are going to expire in less than **30** days. Note: we can adjust this number of days as we think is reasonable.