### PR TITLE
PIA-1841: Fix retain cycle in refresh tokens use cases

### DIFF
--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -2,6 +2,9 @@
 import Foundation
 
 public class AccountFactory {
+    public static func makeLoginUseCase() -> LoginUseCaseType {
+        LoginUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), apiTokenProvider: makeAPITokenProvider(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
+    }
     
     static func makeRefreshAPITokenUseCase() -> RefreshAPITokenUseCaseType {
         RefreshAPITokenUseCase(apiTokenProvider: makeAPITokenProvider())

--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -3,12 +3,12 @@ import Foundation
 
 public class AccountFactory {
     
-    public static func makeRefreshAPITokenUseCase() -> RefreshAPITokenUseCaseType {
-        RefreshAPITokenUseCase(apiTokenProvider: makeAPITokenProvider(), networkClient: NetworkRequestFactory.maketNetworkRequestClient())
+    static func makeRefreshAPITokenUseCase() -> RefreshAPITokenUseCaseType {
+        RefreshAPITokenUseCase(apiTokenProvider: makeAPITokenProvider())
     }
     
-    public static func makeRefreshVpnTokenUseCase() -> RefreshVpnTokenUseCaseType {
-        RefreshVpnTokenUseCase(vpnTokenProvider: makeVpnTokenProvider(), networkRequestClient: NetworkRequestFactory.maketNetworkRequestClient())
+    static func makeRefreshVpnTokenUseCase() -> RefreshVpnTokenUseCaseType {
+        RefreshVpnTokenUseCase(vpnTokenProvider: makeVpnTokenProvider())
         
     }
     

--- a/Sources/PIALibrary/Account/Data/Networking/LoginRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/LoginRequestConfiguration.swift
@@ -1,20 +1,22 @@
 
+
 import Foundation
 import NWHttpConnection
 
-struct RefreshVpnTokenRequestConfiguration: NetworkRequestConfigurationType {
+struct LoginRequestConfiguration: NetworkRequestConfigurationType {
+    
     let networkRequestModule: NetworkRequestModule = .account
-    let path: RequestAPI.Path = .vpnToken
+    let path: RequestAPI.Path = .login
     let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .post
     let contentType: NetworkRequestContentType = .json
-    let inlcudeAuthHeaders: Bool = true
+    let inlcudeAuthHeaders: Bool = false
     
-    // Refreshing the auth tokens is not needed before executing the refresh Vpn token request
+    // Refreshing the auth tokens is not needed before executing the login request
     let refreshAuthTokensIfNeeded: Bool = false
     
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
-    let body: Data? = nil
+    var body: Data? = nil
     let timeout: TimeInterval = 10
-    let requestQueue: DispatchQueue? = DispatchQueue(label: "refresh.vpn_token.queue")
+    let requestQueue: DispatchQueue? = DispatchQueue(label: "login_request.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/RefreshApiTokenRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/RefreshApiTokenRequestConfiguration.swift
@@ -6,6 +6,7 @@ struct RefreshApiTokenRequestConfiguration: NetworkRequestConfigurationType {
     let networkRequestModule: NetworkRequestModule = .account
     let path: RequestAPI.Path = .refreshApiToken
     let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .post
+    let contentType: NetworkRequestContentType = .json
     let inlcudeAuthHeaders: Bool = true
     
     // Refreshing the auth tokens is not needed before executing the refresh API token request

--- a/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
+++ b/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
@@ -3,7 +3,7 @@ import Foundation
 
 protocol RefreshAuthTokensCheckerType {
     typealias Completion = ((NetworkRequestError?) -> Void)
-    func refreshIfNeeded(completion: @escaping Completion)
+    func refreshIfNeeded(with networkClient: NetworkRequestClientType, completion: @escaping Completion)
 }
 
 class RefreshAuthTokensChecker: RefreshAuthTokensCheckerType {
@@ -23,15 +23,15 @@ class RefreshAuthTokensChecker: RefreshAuthTokensCheckerType {
         self.refreshVpnTokenUseCase = refreshVpnTokenUseCase
     }
     
-    func refreshIfNeeded(completion: @escaping Completion) {
+    func refreshIfNeeded(with networkClient: NetworkRequestClientType, completion: @escaping Completion) {
         
         switch (shouldRefreshApiToken(), shouldRefreshVpnToken()) {
         case (true, true):
-            refreshBothTokens(with: completion)
+            refreshBothTokens(with: networkClient, and: completion)
         case (true, false):
-            refreshApiToken(with: completion)
+            refreshApiToken(with: networkClient, and: completion)
         case(false, true):
-            refreshVpnToken(with: completion)
+            refreshVpnToken(with: networkClient, and: completion)
         case(false, false):
             completion(nil)
         }
@@ -43,26 +43,26 @@ class RefreshAuthTokensChecker: RefreshAuthTokensCheckerType {
 
 private extension RefreshAuthTokensChecker {
     
-    func refreshBothTokens(with completion: @escaping Completion) {
-        refreshAPITokenUseCase() { refreshApiTokenError in
+    func refreshBothTokens(with networkClient: NetworkRequestClientType, and completion: @escaping Completion) {
+        refreshAPITokenUseCase(with: networkClient) { refreshApiTokenError in
             if let refreshApiTokenError {
                 completion(refreshApiTokenError)
             } else {
-                self.refreshVpnTokenUseCase() { refreshVpnTokenError in
+                self.refreshVpnTokenUseCase(with: networkClient) { refreshVpnTokenError in
                     completion(refreshApiTokenError)
                 }
             }
         }
     }
     
-    func refreshApiToken(with completion: @escaping Completion) {
-        refreshAPITokenUseCase() { error in
+    func refreshApiToken(with networkClient: NetworkRequestClientType, and completion: @escaping Completion) {
+        refreshAPITokenUseCase(with: networkClient) { error in
             completion(error)
         }
     }
     
-    func refreshVpnToken(with completion: @escaping Completion) {
-        refreshVpnTokenUseCase() { error in
+    func refreshVpnToken(with networkClient: NetworkRequestClientType, and completion: @escaping Completion) {
+        refreshVpnTokenUseCase(with: networkClient) { error in
             completion(error)
         }
     }

--- a/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
+++ b/Sources/PIALibrary/Account/Data/RefreshAuthTokensChecker.swift
@@ -49,11 +49,7 @@ private extension RefreshAuthTokensChecker {
                 completion(refreshApiTokenError)
             } else {
                 self.refreshVpnTokenUseCase() { refreshVpnTokenError in
-                    if let refreshVpnTokenError {
-                        completion(refreshVpnTokenError)
-                    } else {
-                        completion(nil)
-                    }
+                    completion(refreshApiTokenError)
                 }
             }
         }
@@ -61,23 +57,16 @@ private extension RefreshAuthTokensChecker {
     
     func refreshApiToken(with completion: @escaping Completion) {
         refreshAPITokenUseCase() { error in
-            self.handleRefreshResponse(with: error, completion: completion)
+            completion(error)
         }
     }
     
     func refreshVpnToken(with completion: @escaping Completion) {
         refreshVpnTokenUseCase() { error in
-            self.handleRefreshResponse(with: error, completion: completion)
+            completion(error)
         }
     }
     
-    func handleRefreshResponse(with error: NetworkRequestError?, completion: @escaping Completion) {
-        if let error {
-            completion(error)
-        } else {
-            completion(nil)
-        }
-    }
 }
 
 // MARK: - Refresh time intervals utils

--- a/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
@@ -1,0 +1,73 @@
+
+import Foundation
+
+public protocol LoginUseCaseType {
+    typealias Completion = ((NetworkRequestError?) -> Void)
+    func login(with credentials: Credentials, completion: @escaping Completion)
+}
+
+
+class LoginUseCase: LoginUseCaseType {
+    private let networkClient: NetworkRequestClientType
+    private let apiTokenProvider: APITokenProviderType
+    private let refreshVpnTokenUseCase: RefreshVpnTokenUseCaseType
+    
+    init(networkClient: NetworkRequestClientType, apiTokenProvider: APITokenProviderType, refreshVpnTokenUseCase: RefreshVpnTokenUseCaseType) {
+        self.networkClient = networkClient
+        self.apiTokenProvider = apiTokenProvider
+        self.refreshVpnTokenUseCase = refreshVpnTokenUseCase
+    }
+    
+    func login(with credentials: Credentials, completion: @escaping Completion) {
+        
+        var configuration = LoginRequestConfiguration()
+        let credentialsDictionary: [String: String] = [
+            "username": credentials.username,
+            "password": credentials.password
+        ]
+        
+        if let credentialsData = try? JSONEncoder().encode(credentialsDictionary) {
+            configuration.body = credentialsData
+        }
+        
+        networkClient.executeRequest(with: configuration) {[weak self] error, dataResponse in
+            
+            guard let self else { return }
+            
+            if let error {
+                completion(error)
+            } else if let dataResponse {
+                self.handleDataResponse(dataResponse, completion: completion)
+            } else {
+                completion(NetworkRequestError.allConnectionAttemptsFailed)
+            }
+            
+        }
+        
+        
+        
+    }
+}
+
+private extension LoginUseCase {
+    private func handleDataResponse(_ dataResponse: NetworkRequestResponseType, completion: @escaping RefreshVpnTokenUseCaseType.Completion) {
+        
+        guard let dataResponseContent = dataResponse.data else {
+            completion(NetworkRequestError.noDataContent)
+            return
+        }
+        
+        do {
+            try apiTokenProvider.saveAPIToken(from: dataResponseContent)
+
+            // Refresh the Vpn token after successfully login
+           refreshVpnTokenUseCase(with: self.networkClient) { error in
+                completion(error)
+            }
+            
+        } catch {
+            // TODO: Map error to the ones that the app is expecting/handling
+            completion(NetworkRequestError.unableToSaveAPIToken)
+        }
+    }
+}

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
@@ -2,22 +2,20 @@
 import Foundation
 import NWHttpConnection
 
-public protocol RefreshAPITokenUseCaseType {
+protocol RefreshAPITokenUseCaseType {
     typealias Completion = ((NetworkRequestError?) -> Void)
-    func callAsFunction(completion: @escaping RefreshAPITokenUseCaseType.Completion)
+    func callAsFunction(with networkClient: NetworkRequestClientType, completion: @escaping RefreshAPITokenUseCaseType.Completion)
 }
 
 class RefreshAPITokenUseCase: RefreshAPITokenUseCaseType {
     
     private let apiTokenProvider: APITokenProviderType
-    private let networkClient: NetworkRequestClientType
     
-    init(apiTokenProvider: APITokenProviderType, networkClient: NetworkRequestClientType) {
+    init(apiTokenProvider: APITokenProviderType) {
         self.apiTokenProvider = apiTokenProvider
-        self.networkClient = networkClient
     }
     
-    func callAsFunction(completion: @escaping RefreshAPITokenUseCaseType.Completion) {
+    func callAsFunction(with networkClient: NetworkRequestClientType, completion: @escaping RefreshAPITokenUseCaseType.Completion) {
         
         let configuration = RefreshApiTokenRequestConfiguration()
         

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
@@ -1,30 +1,27 @@
 
 import Foundation
 
-public protocol RefreshVpnTokenUseCaseType {
+protocol RefreshVpnTokenUseCaseType {
     typealias Completion = ((NetworkRequestError?) -> Void)
-    func callAsFunction(completion: @escaping RefreshVpnTokenUseCaseType.Completion)
+    func callAsFunction(with networkClient: NetworkRequestClientType, completion: @escaping RefreshVpnTokenUseCaseType.Completion)
 }
 
 class RefreshVpnTokenUseCase: RefreshVpnTokenUseCaseType {
     
     private let vpnTokenProvider: VpnTokenProviderType
-    private let networkClient: NetworkRequestClientType
     
-    init(vpnTokenProvider: VpnTokenProviderType,
-         networkRequestClient: NetworkRequestClientType) {
+    init(vpnTokenProvider: VpnTokenProviderType) {
         self.vpnTokenProvider = vpnTokenProvider
-        self.networkClient = networkRequestClient
     }
     
-    func callAsFunction(completion: @escaping RefreshVpnTokenUseCaseType.Completion) {
+    func callAsFunction(with networkClient: NetworkRequestClientType, completion: @escaping RefreshVpnTokenUseCaseType.Completion) {
         
         let configuration = RefreshVpnTokenRequestConfiguration()
         
         networkClient.executeRequest(with: configuration) { [weak self] error, dataResponse in
-            
+            NSLog(">>> Refresh vpn token use case, request with config: \(configuration)")
             guard let self else { return }
-            
+            NSLog(">>> Refresh vpn token use case, data response: \(dataResponse) -- error: \(error)")
             if let error {
                 completion(error)
             } else if let dataResponse {

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
@@ -19,9 +19,8 @@ class RefreshVpnTokenUseCase: RefreshVpnTokenUseCaseType {
         let configuration = RefreshVpnTokenRequestConfiguration()
         
         networkClient.executeRequest(with: configuration) { [weak self] error, dataResponse in
-            NSLog(">>> Refresh vpn token use case, request with config: \(configuration)")
             guard let self else { return }
-            NSLog(">>> Refresh vpn token use case, data response: \(dataResponse) -- error: \(error)")
+            
             if let error {
                 completion(error)
             } else if let dataResponse {

--- a/Sources/PIALibrary/Common/Data/Networking/Interfaces/NetworkRequestConfigurationType.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/Interfaces/NetworkRequestConfigurationType.swift
@@ -6,11 +6,19 @@ enum NetworkRequestModule {
     case account
 }
 
+enum NetworkRequestContentType: String {
+    case json = "application/json"
+    case textHtml = "text/html"
+    case formData = "multipart/form-data"
+}
+
 protocol NetworkRequestConfigurationType {
+    
     var networkRequestModule: NetworkRequestModule { get }
     var path: RequestAPI.Path { get }
     var httpMethod: NWConnectionHTTPMethod { get }
     var inlcudeAuthHeaders: Bool { get }
+    var contentType: NetworkRequestContentType { get }
     var refreshAuthTokensIfNeeded: Bool { get }
     var urlQueryParameters: [String: String]? { get }
     var responseDataType: NWDataResponseType { get }

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkConnectionRequestProvider.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkConnectionRequestProvider.swift
@@ -30,17 +30,16 @@ class NetworkConnectionRequestProvider: NetworkConnectionRequestProviderType {
             return nil
         }
         
-        var authHeaders: [String: String]?
+        var headers: [String: String] = ["Content-Type": configuration.contentType.rawValue]
+        
         if configuration.inlcudeAuthHeaders {
             guard let apiToken = apiTokenProvider.getAPIToken() else {
                 return nil
             }
-            authHeaders = [
-                "Authorization": "Token \(apiToken.apiToken)"
-            ]
+            headers["Authorization"] = "Token \(apiToken.apiToken)"
         }
         
-        let connectionConfiguration = NWConnectionConfiguration(url: requestURL, method: configuration.httpMethod, headers: authHeaders, body: configuration.body, certificateValidation: makeCertificateValidation(for: endpoint, anchorCertificate: anchorCertificate), dataResponseType: configuration.responseDataType, timeout: configuration.timeout, queue: configuration.requestQueue)
+        let connectionConfiguration = NWConnectionConfiguration(url: requestURL, method: configuration.httpMethod, headers: headers, body: configuration.body, certificateValidation: makeCertificateValidation(for: endpoint, anchorCertificate: anchorCertificate), dataResponseType: configuration.responseDataType, timeout: configuration.timeout, queue: configuration.requestQueue)
         
         return NWHttpConnectionFactory.makeNWHttpConnection(with: connectionConfiguration)
         

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
@@ -47,7 +47,7 @@ private extension NetworkRequestClient {
     
     func startRequest(with configuration: NetworkRequestConfigurationType, completion: @escaping Completion) {
         let endpoints = getEndpoints(for: configuration.networkRequestModule)
-        
+
         let connections = endpoints.compactMap { endpoint in
             self.networkConnectionRequestProvider.makeNetworkRequestConnection(for: endpoint, with: configuration)
         }
@@ -73,6 +73,7 @@ private extension NetworkRequestClient {
         }
         
         execute(connection: nextConnection) { error, responseData in
+
             if error != nil {
                 tryNextConnectionOrFail()
             } else if let responseData {

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
@@ -24,7 +24,7 @@ class NetworkRequestClient: NetworkRequestClientType {
 
         if configuration.refreshAuthTokensIfNeeded {
             // 1. Refresh the auth tokens before executing the request
-            refreshAuthTokensChecker.refreshIfNeeded { error in
+            refreshAuthTokensChecker.refreshIfNeeded(with: self) { error in
                 if let error {
                     // The request fails if refreshing the tokens have failed
                     completion(error, nil)

--- a/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -215,6 +215,12 @@ class PIAWebServices: WebServices, ConfigurationAccess {
     }
 
     func info(_ callback: ((AccountInfo?, Error?) -> Void)?) {
+        NSLog(">>> >>> Will refresh token..")
+        let uc = AccountFactory.makeRefreshVpnTokenUseCase()
+        uc.callAsFunction(with: NetworkRequestFactory.maketNetworkRequestClient()) { error in
+            NSLog(">>> >>> Refresh token error: \(error)")
+        }
+        
         self.accountAPI.accountDetails() { [weak self] (response, errors) in
             if !errors.isEmpty {
                 callback?(nil, self?.mapAccountDetailsError(errors.last!))

--- a/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -215,11 +215,6 @@ class PIAWebServices: WebServices, ConfigurationAccess {
     }
 
     func info(_ callback: ((AccountInfo?, Error?) -> Void)?) {
-        NSLog(">>> >>> Will refresh token..")
-        let uc = AccountFactory.makeRefreshVpnTokenUseCase()
-        uc.callAsFunction(with: NetworkRequestFactory.maketNetworkRequestClient()) { error in
-            NSLog(">>> >>> Refresh token error: \(error)")
-        }
         
         self.accountAPI.accountDetails() { [weak self] (response, errors) in
             if !errors.isEmpty {

--- a/Tests/PIALibraryTests/Mocks/File.swift
+++ b/Tests/PIALibraryTests/Mocks/File.swift
@@ -1,0 +1,17 @@
+
+import Foundation
+import NWHttpConnection
+
+@testable import PIALibrary
+
+class NetworkRequestClientMock: NetworkRequestClientType {
+    
+    var executeRequestCalledAttempt = 0
+    var executeRequestError: NetworkRequestError?
+    var executeRequestResponse: NetworkRequestResponseType?
+    
+    func executeRequest(with configuration: NetworkRequestConfigurationType, completion: @escaping Completion) {
+        executeRequestCalledAttempt += 1
+        completion(executeRequestError, executeRequestResponse)
+    }
+}

--- a/Tests/PIALibraryTests/Mocks/NetworkRequestConfigurationMock.swift
+++ b/Tests/PIALibraryTests/Mocks/NetworkRequestConfigurationMock.swift
@@ -13,6 +13,7 @@ struct NetworkRequestConfigurationMock: NetworkRequestConfigurationType {
     var path: RequestAPI.Path = .vpnToken
     var httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .get
     var inlcudeAuthHeaders: Bool = true
+    var contentType: NetworkRequestContentType = .json
     var urlQueryParameters: [String : String]? = nil
     var responseDataType: NWHttpConnection.NWDataResponseType = .jsonData
     var body: Data? = nil

--- a/Tests/PIALibraryTests/Mocks/RefreshAPITokenUseCaseMock.swift
+++ b/Tests/PIALibraryTests/Mocks/RefreshAPITokenUseCaseMock.swift
@@ -3,10 +3,11 @@ import Foundation
 @testable import PIALibrary
 
 class RefreshAPITokenUseCaseMock: RefreshAPITokenUseCaseType {
+    
     var callAsFunctionCalledAttempt = 0
     var completionError: NetworkRequestError?
     
-    func callAsFunction(completion: @escaping ((NetworkRequestError?) -> Void)) {
+    func callAsFunction(with networkClient: NetworkRequestClientType, completion: @escaping ((NetworkRequestError?) -> Void)) {
         callAsFunctionCalledAttempt += 1
         completion(completionError)
     }

--- a/Tests/PIALibraryTests/Mocks/RefreshAuthTokensCheckerMock.swift
+++ b/Tests/PIALibraryTests/Mocks/RefreshAuthTokensCheckerMock.swift
@@ -7,7 +7,7 @@ class RefreshAuthTokensCheckerMock: RefreshAuthTokensCheckerType {
     
     var refreshIfNeededCalledAttempt = 0
     var refreshIfNeededError: NetworkRequestError? = nil
-    func refreshIfNeeded(completion: @escaping Completion) {
+    func refreshIfNeeded(with networkClient: NetworkRequestClientType, completion: @escaping Completion) {
         refreshIfNeededCalledAttempt += 1
         completion(refreshIfNeededError)
     }

--- a/Tests/PIALibraryTests/Mocks/RefreshVpnTokenUseCaseMock.swift
+++ b/Tests/PIALibraryTests/Mocks/RefreshVpnTokenUseCaseMock.swift
@@ -7,7 +7,7 @@ class RefreshVpnTokenUseCaseMock: RefreshVpnTokenUseCaseType {
     var callAsFunctionCalledAttempt = 0
     var completionError: NetworkRequestError?
     
-    func callAsFunction(completion: @escaping ((NetworkRequestError?) -> Void)) {
+    func callAsFunction(with networkClient: NetworkRequestClientType, completion: @escaping ((NetworkRequestError?) -> Void)) {
         callAsFunctionCalledAttempt += 1
         completion(completionError)
     }

--- a/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
+++ b/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
@@ -1,242 +1,242 @@
-
-import XCTest
-@testable import PIALibrary
-
-class RefreshAuthTokensCheckerTests: XCTestCase {
-    class Fixture {
-        let apiTokenProviderMock = APITokenProviderMock()
-        let vpnTokenProviderMock = VpnTokenProviderMock()
-        let refreshAPITokenUseCaseMock = RefreshAPITokenUseCaseMock()
-        let refreshVpnTokenUseCaseMock = RefreshVpnTokenUseCaseMock()
-        
-        let expirationDateIn10Days = Calendar.current.date(byAdding: .day, value: 10, to: Date())!
-        let expirationDateIn31Days = Calendar.current.date(byAdding: .day, value: 31, to: Date())!
-        let expired1DayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-        
-        func stubAPIToken(with expirationDate: Date) {
-            let apiToken = APIToken(apiToken: "some_api_token", expiresAt: expirationDate)
-            apiTokenProviderMock.getAPITokenResult = apiToken
-        }
-        
-        func stubVpnToken(with expirationDate: Date) {
-            let vpnToken = VpnToken(vpnUsernameToken: "token_username", vpnPasswordToken: "token_password", expiresAt: expirationDate)
-            vpnTokenProviderMock.getVpnTokenResult = vpnToken
-        }
-        
-        func stubRefreshAPIToken(with error: NetworkRequestError?) {
-            refreshAPITokenUseCaseMock.completionError = error
-        }
-        
-        func stubRefreshVpnToken(with error: NetworkRequestError?) {
-            refreshVpnTokenUseCaseMock.completionError = error
-        }
-        
-        
-    }
-    
-    var fixture: Fixture!
-    var sut: RefreshAuthTokensChecker!
-    
-    override func setUp() {
-        fixture = Fixture()
-    }
-    
-    override func tearDown() {
-        fixture = nil
-        sut = nil
-    }
-    
-    private func instantiateSut() {
-        sut = RefreshAuthTokensChecker(apiTokenProvider: fixture.apiTokenProviderMock, vpnTokenProvier: fixture.vpnTokenProviderMock, refreshAPITokenUseCase: fixture.refreshAPITokenUseCaseMock, refreshVpnTokenUseCase: fixture.refreshVpnTokenUseCaseMock)
-    }
-    
-    
-    func testRefreshTokensWithSuccess_WhenBothExpireIn10Days() {
-        // GIVEN that both the API token and Vpn token will expire in 10 days
-        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
-        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN both tokens are refreshed
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        
-        // AND no error is returned
-        XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-    func testRefreshTokensWithError_WhenBothExpireIn10Days() {
-        // GIVEN that both the API token and Vpn token will expire in 10 days
-        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
-        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
-        
-        // AND GIVEN that refreshing the API token request fails
-        fixture.stubRefreshAPIToken(with: .apiTokenNotFound)
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN only the request to refresh the api token is called
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-        
-        // AND an error is returned
-        XCTAssertNotNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-    
-    func testRefreshTokens_WhenBothExpireInMoreThan30Days() {
-        // GIVEN that both the API token and Vpn token will expire in 31 days
-        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
-        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN the tokens don't get refreshed
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-        
-        // AND no error is returned
-        XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-    func testRefreshTokens_WhenAPITokenIsAboutExpiring() {
-        // GIVEN that the the API token expires in 10 days
-        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
-        // AND that the the Vpn token expires in 31 days
-        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN Only the API token is refreshed
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-        
-        // AND no error is returned
-        XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-    func testRefreshTokens_WhenVpnTokenIsAboutExpiring() {
-        // GIVEN that the the API token expires in 31 days
-        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
-        // AND that the the Vpn token expires in 10 days
-        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN Only the Vpn token is refreshed
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        
-        // AND no error is returned
-        XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-    func testRefreshTokens_WhenBothTokensHaveExpired() {
-        // GIVEN that both the API token and Vpn token have expired
-        fixture.stubAPIToken(with: fixture.expired1DayAgo)
-        fixture.stubVpnToken(with: fixture.expired1DayAgo)
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN both tokens are refreshed
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        
-        // AND no error is returned
-        XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-    func testRefreshTokens_WhenNoneOfTheTokensAreFound() {
-        // GIVEN that there is no API token and Vpn token saved
-        fixture.apiTokenProviderMock.getAPITokenResult = nil
-        fixture.vpnTokenProviderMock.getVpnTokenResult = nil
-        
-        instantiateSut()
-        
-        let expectation = expectation(description: "Refresh call is finished")
-        var capturedError: NetworkRequestError? = nil
-        
-        // WHEN calling refresh if needed
-        sut.refreshIfNeeded { error in
-            capturedError = error
-            expectation.fulfill()
-        }
-        
-        // THEN both tokens are refreshed
-        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-        
-        // AND no error is returned
-        XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
-    }
-    
-}
+//
+//import XCTest
+//@testable import PIALibrary
+//
+//class RefreshAuthTokensCheckerTests: XCTestCase {
+//    class Fixture {
+//        let apiTokenProviderMock = APITokenProviderMock()
+//        let vpnTokenProviderMock = VpnTokenProviderMock()
+//        let refreshAPITokenUseCaseMock = RefreshAPITokenUseCaseMock()
+//        let refreshVpnTokenUseCaseMock = RefreshVpnTokenUseCaseMock()
+//        
+//        let expirationDateIn10Days = Calendar.current.date(byAdding: .day, value: 10, to: Date())!
+//        let expirationDateIn31Days = Calendar.current.date(byAdding: .day, value: 31, to: Date())!
+//        let expired1DayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+//        
+//        func stubAPIToken(with expirationDate: Date) {
+//            let apiToken = APIToken(apiToken: "some_api_token", expiresAt: expirationDate)
+//            apiTokenProviderMock.getAPITokenResult = apiToken
+//        }
+//        
+//        func stubVpnToken(with expirationDate: Date) {
+//            let vpnToken = VpnToken(vpnUsernameToken: "token_username", vpnPasswordToken: "token_password", expiresAt: expirationDate)
+//            vpnTokenProviderMock.getVpnTokenResult = vpnToken
+//        }
+//        
+//        func stubRefreshAPIToken(with error: NetworkRequestError?) {
+//            refreshAPITokenUseCaseMock.completionError = error
+//        }
+//        
+//        func stubRefreshVpnToken(with error: NetworkRequestError?) {
+//            refreshVpnTokenUseCaseMock.completionError = error
+//        }
+//        
+//        
+//    }
+//    
+//    var fixture: Fixture!
+//    var sut: RefreshAuthTokensChecker!
+//    
+//    override func setUp() {
+//        fixture = Fixture()
+//    }
+//    
+//    override func tearDown() {
+//        fixture = nil
+//        sut = nil
+//    }
+//    
+//    private func instantiateSut() {
+//        sut = RefreshAuthTokensChecker(apiTokenProvider: fixture.apiTokenProviderMock, vpnTokenProvier: fixture.vpnTokenProviderMock, refreshAPITokenUseCase: fixture.refreshAPITokenUseCaseMock, refreshVpnTokenUseCase: fixture.refreshVpnTokenUseCaseMock)
+//    }
+//    
+//    
+//    func testRefreshTokensWithSuccess_WhenBothExpireIn10Days() {
+//        // GIVEN that both the API token and Vpn token will expire in 10 days
+//        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+//        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN both tokens are refreshed
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        
+//        // AND no error is returned
+//        XCTAssertNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//    func testRefreshTokensWithError_WhenBothExpireIn10Days() {
+//        // GIVEN that both the API token and Vpn token will expire in 10 days
+//        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+//        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+//        
+//        // AND GIVEN that refreshing the API token request fails
+//        fixture.stubRefreshAPIToken(with: .apiTokenNotFound)
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN only the request to refresh the api token is called
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+//        
+//        // AND an error is returned
+//        XCTAssertNotNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//    
+//    func testRefreshTokens_WhenBothExpireInMoreThan30Days() {
+//        // GIVEN that both the API token and Vpn token will expire in 31 days
+//        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
+//        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN the tokens don't get refreshed
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+//        
+//        // AND no error is returned
+//        XCTAssertNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//    func testRefreshTokens_WhenAPITokenIsAboutExpiring() {
+//        // GIVEN that the the API token expires in 10 days
+//        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+//        // AND that the the Vpn token expires in 31 days
+//        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN Only the API token is refreshed
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+//        
+//        // AND no error is returned
+//        XCTAssertNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//    func testRefreshTokens_WhenVpnTokenIsAboutExpiring() {
+//        // GIVEN that the the API token expires in 31 days
+//        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
+//        // AND that the the Vpn token expires in 10 days
+//        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN Only the Vpn token is refreshed
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        
+//        // AND no error is returned
+//        XCTAssertNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//    func testRefreshTokens_WhenBothTokensHaveExpired() {
+//        // GIVEN that both the API token and Vpn token have expired
+//        fixture.stubAPIToken(with: fixture.expired1DayAgo)
+//        fixture.stubVpnToken(with: fixture.expired1DayAgo)
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN both tokens are refreshed
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        
+//        // AND no error is returned
+//        XCTAssertNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//    func testRefreshTokens_WhenNoneOfTheTokensAreFound() {
+//        // GIVEN that there is no API token and Vpn token saved
+//        fixture.apiTokenProviderMock.getAPITokenResult = nil
+//        fixture.vpnTokenProviderMock.getVpnTokenResult = nil
+//        
+//        instantiateSut()
+//        
+//        let expectation = expectation(description: "Refresh call is finished")
+//        var capturedError: NetworkRequestError? = nil
+//        
+//        // WHEN calling refresh if needed
+//        sut.refreshIfNeeded { error in
+//            capturedError = error
+//            expectation.fulfill()
+//        }
+//        
+//        // THEN both tokens are refreshed
+//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+//        
+//        // AND no error is returned
+//        XCTAssertNil(capturedError)
+//        
+//        wait(for: [expectation], timeout: 3)
+//    }
+//    
+//}

--- a/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
+++ b/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
@@ -1,242 +1,243 @@
-//
-//import XCTest
-//@testable import PIALibrary
-//
-//class RefreshAuthTokensCheckerTests: XCTestCase {
-//    class Fixture {
-//        let apiTokenProviderMock = APITokenProviderMock()
-//        let vpnTokenProviderMock = VpnTokenProviderMock()
-//        let refreshAPITokenUseCaseMock = RefreshAPITokenUseCaseMock()
-//        let refreshVpnTokenUseCaseMock = RefreshVpnTokenUseCaseMock()
-//        
-//        let expirationDateIn10Days = Calendar.current.date(byAdding: .day, value: 10, to: Date())!
-//        let expirationDateIn31Days = Calendar.current.date(byAdding: .day, value: 31, to: Date())!
-//        let expired1DayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-//        
-//        func stubAPIToken(with expirationDate: Date) {
-//            let apiToken = APIToken(apiToken: "some_api_token", expiresAt: expirationDate)
-//            apiTokenProviderMock.getAPITokenResult = apiToken
-//        }
-//        
-//        func stubVpnToken(with expirationDate: Date) {
-//            let vpnToken = VpnToken(vpnUsernameToken: "token_username", vpnPasswordToken: "token_password", expiresAt: expirationDate)
-//            vpnTokenProviderMock.getVpnTokenResult = vpnToken
-//        }
-//        
-//        func stubRefreshAPIToken(with error: NetworkRequestError?) {
-//            refreshAPITokenUseCaseMock.completionError = error
-//        }
-//        
-//        func stubRefreshVpnToken(with error: NetworkRequestError?) {
-//            refreshVpnTokenUseCaseMock.completionError = error
-//        }
-//        
-//        
-//    }
-//    
-//    var fixture: Fixture!
-//    var sut: RefreshAuthTokensChecker!
-//    
-//    override func setUp() {
-//        fixture = Fixture()
-//    }
-//    
-//    override func tearDown() {
-//        fixture = nil
-//        sut = nil
-//    }
-//    
-//    private func instantiateSut() {
-//        sut = RefreshAuthTokensChecker(apiTokenProvider: fixture.apiTokenProviderMock, vpnTokenProvier: fixture.vpnTokenProviderMock, refreshAPITokenUseCase: fixture.refreshAPITokenUseCaseMock, refreshVpnTokenUseCase: fixture.refreshVpnTokenUseCaseMock)
-//    }
-//    
-//    
-//    func testRefreshTokensWithSuccess_WhenBothExpireIn10Days() {
-//        // GIVEN that both the API token and Vpn token will expire in 10 days
-//        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
-//        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN both tokens are refreshed
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        
-//        // AND no error is returned
-//        XCTAssertNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//    func testRefreshTokensWithError_WhenBothExpireIn10Days() {
-//        // GIVEN that both the API token and Vpn token will expire in 10 days
-//        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
-//        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
-//        
-//        // AND GIVEN that refreshing the API token request fails
-//        fixture.stubRefreshAPIToken(with: .apiTokenNotFound)
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN only the request to refresh the api token is called
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-//        
-//        // AND an error is returned
-//        XCTAssertNotNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//    
-//    func testRefreshTokens_WhenBothExpireInMoreThan30Days() {
-//        // GIVEN that both the API token and Vpn token will expire in 31 days
-//        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
-//        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN the tokens don't get refreshed
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-//        
-//        // AND no error is returned
-//        XCTAssertNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//    func testRefreshTokens_WhenAPITokenIsAboutExpiring() {
-//        // GIVEN that the the API token expires in 10 days
-//        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
-//        // AND that the the Vpn token expires in 31 days
-//        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN Only the API token is refreshed
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-//        
-//        // AND no error is returned
-//        XCTAssertNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//    func testRefreshTokens_WhenVpnTokenIsAboutExpiring() {
-//        // GIVEN that the the API token expires in 31 days
-//        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
-//        // AND that the the Vpn token expires in 10 days
-//        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN Only the Vpn token is refreshed
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        
-//        // AND no error is returned
-//        XCTAssertNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//    func testRefreshTokens_WhenBothTokensHaveExpired() {
-//        // GIVEN that both the API token and Vpn token have expired
-//        fixture.stubAPIToken(with: fixture.expired1DayAgo)
-//        fixture.stubVpnToken(with: fixture.expired1DayAgo)
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN both tokens are refreshed
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        
-//        // AND no error is returned
-//        XCTAssertNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//    func testRefreshTokens_WhenNoneOfTheTokensAreFound() {
-//        // GIVEN that there is no API token and Vpn token saved
-//        fixture.apiTokenProviderMock.getAPITokenResult = nil
-//        fixture.vpnTokenProviderMock.getVpnTokenResult = nil
-//        
-//        instantiateSut()
-//        
-//        let expectation = expectation(description: "Refresh call is finished")
-//        var capturedError: NetworkRequestError? = nil
-//        
-//        // WHEN calling refresh if needed
-//        sut.refreshIfNeeded { error in
-//            capturedError = error
-//            expectation.fulfill()
-//        }
-//        
-//        // THEN both tokens are refreshed
-//        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
-//        
-//        // AND no error is returned
-//        XCTAssertNil(capturedError)
-//        
-//        wait(for: [expectation], timeout: 3)
-//    }
-//    
-//}
+
+import XCTest
+@testable import PIALibrary
+
+class RefreshAuthTokensCheckerTests: XCTestCase {
+    class Fixture {
+        let apiTokenProviderMock = APITokenProviderMock()
+        let vpnTokenProviderMock = VpnTokenProviderMock()
+        let refreshAPITokenUseCaseMock = RefreshAPITokenUseCaseMock()
+        let refreshVpnTokenUseCaseMock = RefreshVpnTokenUseCaseMock()
+        let networkClientMock = NetworkRequestClientMock()
+        
+        let expirationDateIn10Days = Calendar.current.date(byAdding: .day, value: 10, to: Date())!
+        let expirationDateIn31Days = Calendar.current.date(byAdding: .day, value: 31, to: Date())!
+        let expired1DayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        
+        func stubAPIToken(with expirationDate: Date) {
+            let apiToken = APIToken(apiToken: "some_api_token", expiresAt: expirationDate)
+            apiTokenProviderMock.getAPITokenResult = apiToken
+        }
+        
+        func stubVpnToken(with expirationDate: Date) {
+            let vpnToken = VpnToken(vpnUsernameToken: "token_username", vpnPasswordToken: "token_password", expiresAt: expirationDate)
+            vpnTokenProviderMock.getVpnTokenResult = vpnToken
+        }
+        
+        func stubRefreshAPIToken(with error: NetworkRequestError?) {
+            refreshAPITokenUseCaseMock.completionError = error
+        }
+        
+        func stubRefreshVpnToken(with error: NetworkRequestError?) {
+            refreshVpnTokenUseCaseMock.completionError = error
+        }
+        
+        
+    }
+    
+    var fixture: Fixture!
+    var sut: RefreshAuthTokensChecker!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = RefreshAuthTokensChecker(apiTokenProvider: fixture.apiTokenProviderMock, vpnTokenProvier: fixture.vpnTokenProviderMock, refreshAPITokenUseCase: fixture.refreshAPITokenUseCaseMock, refreshVpnTokenUseCase: fixture.refreshVpnTokenUseCaseMock)
+    }
+    
+    
+    func testRefreshTokensWithSuccess_WhenBothExpireIn10Days() {
+        // GIVEN that both the API token and Vpn token will expire in 10 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN both tokens are refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokensWithError_WhenBothExpireIn10Days() {
+        // GIVEN that both the API token and Vpn token will expire in 10 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+        
+        // AND GIVEN that refreshing the API token request fails
+        fixture.stubRefreshAPIToken(with: .apiTokenNotFound)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN only the request to refresh the api token is called
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    
+    func testRefreshTokens_WhenBothExpireInMoreThan30Days() {
+        // GIVEN that both the API token and Vpn token will expire in 31 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
+        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the tokens don't get refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokens_WhenAPITokenIsAboutExpiring() {
+        // GIVEN that the the API token expires in 10 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn10Days)
+        // AND that the the Vpn token expires in 31 days
+        fixture.stubVpnToken(with: fixture.expirationDateIn31Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN Only the API token is refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokens_WhenVpnTokenIsAboutExpiring() {
+        // GIVEN that the the API token expires in 31 days
+        fixture.stubAPIToken(with: fixture.expirationDateIn31Days)
+        // AND that the the Vpn token expires in 10 days
+        fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN Only the Vpn token is refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokens_WhenBothTokensHaveExpired() {
+        // GIVEN that both the API token and Vpn token have expired
+        fixture.stubAPIToken(with: fixture.expired1DayAgo)
+        fixture.stubVpnToken(with: fixture.expired1DayAgo)
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN both tokens are refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testRefreshTokens_WhenNoneOfTheTokensAreFound() {
+        // GIVEN that there is no API token and Vpn token saved
+        fixture.apiTokenProviderMock.getAPITokenResult = nil
+        fixture.vpnTokenProviderMock.getVpnTokenResult = nil
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded(with: fixture.networkClientMock) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN both tokens are refreshed
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+}


### PR DESCRIPTION
- This PR fixes a crash caused by a circular dependency between the `NetworkRequestClient` and `RefreshAPITokenUseCase` and between `NetworkRequestClient` and `RefreshVpnUseCase`. This bug was introduced in the following PR when implementing the logic to optionally perform a token refresh before any API request:
https://github.com/pia-foss/mobile-ios-library/pull/35

 The solution proposed in this PR:
- Pass the `NetworkRequestClient` as an arg to each of the Refresh tokens use cases.

This PR also implements:
- Login with Credentials use case