### PR TITLE
PIA-1841: Login with creds and receipt

### DIFF
--- a/Sources/PIALibrary/Account/Data/ClientErrorMapper.swift
+++ b/Sources/PIALibrary/Account/Data/ClientErrorMapper.swift
@@ -1,0 +1,64 @@
+
+
+import Foundation
+
+enum UseCaseType {
+    case login
+    case logout
+}
+
+/// Maps an Network Error with a ClientError
+/// The idea is to use this mapper on `PIAWebServices` to map the errors returned from the Swift implementation of the Accounts Lib with the ones that the app expects
+struct ClientErrorMapper {
+    static func map(networkRequestError: NetworkRequestError, useCase: UseCaseType) -> ClientError {
+        switch (networkRequestError, useCase) {
+        case (.connectionError(let statusCode, let message), _):
+            return getClientError(from: statusCode, useCase: useCase) ?? .unexpectedReply
+               
+        case (.allConnectionAttemptsFailed(let statusCode), _):
+            return getClientError(from: statusCode, useCase: useCase) ?? .unexpectedReply
+            
+        case (.noDataContent, _):
+            return .malformedResponseData
+            
+        case (.noErrorAndNoResponse, _):
+            return .unexpectedReply
+            
+        case (.unableToSaveVpnToken, _):
+            return .unexpectedReply
+            
+        case (.unableToSaveAPIToken, _):
+            return .unexpectedReply
+
+        case (.connectionCompletedWithNoResponse, _):
+            return .malformedResponseData
+            
+        case (.unknown(message: let message), _):
+            return .unexpectedReply
+            
+        case (.unableToDecodeAPIToken, _):
+            return .malformedResponseData
+            
+        case (.unableToDecodeVpnToken, _):
+            return .malformedResponseData
+        }
+    }
+    
+    static func getClientError(from statusCode: Int?, useCase: UseCaseType) -> ClientError? {
+        
+        guard let statusCode,
+              let httpStatusCode = HttpResponseStatusCode(rawValue: statusCode) else {
+            return nil
+        }
+        switch (httpStatusCode, useCase) {
+        case (.unauthorized, _):
+            return .unauthorized
+        case (.throttled, _):
+            return .throttled(retryAfter: 60)
+        default:
+            return nil
+        }
+    }
+    
+    
+}

--- a/Sources/PIALibrary/Account/Data/Networking/LoginLinkRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/LoginLinkRequestConfiguration.swift
@@ -1,0 +1,19 @@
+
+
+import Foundation
+import NWHttpConnection
+
+struct LoginLinkRequestConfiguration: NetworkRequestConfigurationType {
+    
+    let networkRequestModule: NetworkRequestModule = .account
+    let path: RequestAPI.Path = .loginLink
+    let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .post
+    let contentType: NetworkRequestContentType = .json
+    let inlcudeAuthHeaders: Bool = false
+    let urlQueryParameters: [String : String]? = nil
+    let responseDataType: NWDataResponseType = .jsonData
+    var body: Data? = nil
+    let timeout: TimeInterval = 10
+    let requestQueue: DispatchQueue? = DispatchQueue(label: "login_request.queue")
+}
+

--- a/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
@@ -4,6 +4,8 @@ import Foundation
 public protocol LoginUseCaseType {
     typealias Completion = ((NetworkRequestError?) -> Void)
     func login(with credentials: Credentials, completion: @escaping Completion)
+    func login(with receiptBase64: String, completion: @escaping Completion)
+    func loginLink(with email: String, completion: @escaping Completion)
 }
 
 
@@ -21,17 +23,54 @@ class LoginUseCase: LoginUseCaseType {
     func login(with credentials: Credentials, completion: @escaping Completion) {
         
         var configuration = LoginRequestConfiguration()
-        let credentialsDictionary: [String: String] = [
+        let bodyDataDict: [String: String] = [
             "username": credentials.username,
             "password": credentials.password
         ]
         
-        if let credentialsData = try? JSONEncoder().encode(credentialsDictionary) {
-            configuration.body = credentialsData
+        if let bodyData = try? JSONEncoder().encode(bodyDataDict) {
+            configuration.body = bodyData
         }
+        
+        executeNetworkRequest(with: configuration, completion: completion)
+    }
+    
+    func login(with receiptBase64: String, completion: @escaping Completion) {
+        var configuration = LoginRequestConfiguration()
+        let bodyDataDict: [String: String] = [
+            "receipt": receiptBase64
+        ]
+        
+        if let bodyData = try? JSONEncoder().encode(bodyDataDict) {
+            configuration.body = bodyData
+        }
+        
+        executeNetworkRequest(with: configuration, completion: completion)
+    }
+    
+    
+    func loginLink(with email: String, completion: @escaping Completion) {
+        
+        var configuration = LoginLinkRequestConfiguration()
+        let bodyDataDict: [String: String] = [
+            "email": email
+        ]
+        
+        if let bodyData = try? JSONEncoder().encode(bodyDataDict) {
+            configuration.body = bodyData
+        }
+        
+        executeNetworkRequest(with: configuration, completion: completion)
+    }
+}
+
+private extension LoginUseCase {
+    
+    private func executeNetworkRequest(with configuration: NetworkRequestConfigurationType, completion: @escaping Completion) {
         
         networkClient.executeRequest(with: configuration) {[weak self] error, dataResponse in
             
+            NSLog(">>> >>> Login use case error: \(error) -- dataResponse: \(dataResponse)")
             guard let self else { return }
             
             if let error {
@@ -41,20 +80,17 @@ class LoginUseCase: LoginUseCaseType {
             } else {
                 completion(NetworkRequestError.allConnectionAttemptsFailed)
             }
-            
         }
-        
-        
-        
     }
-}
-
-private extension LoginUseCase {
+    
     private func handleDataResponse(_ dataResponse: NetworkRequestResponseType, completion: @escaping RefreshVpnTokenUseCaseType.Completion) {
         
         guard let dataResponseContent = dataResponse.data else {
             completion(NetworkRequestError.noDataContent)
             return
+        }
+        if let data = dataResponse.data {
+            NSLog(">>> >>> LoginUseCase: handle data resp data: \(String(data: data, encoding: .utf8))")
         }
         
         do {

--- a/Sources/PIALibrary/Account/Domain/UseCases/LogoutUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/LogoutUseCase.swift
@@ -1,0 +1,22 @@
+
+import Foundation
+
+protocol LogoutUseCaseType {
+    typealias Completion = ((NetworkRequestError?) -> Void)
+    func logout(completion: @escaping Completion)
+}
+
+class LogoutUseCase: LogoutUseCaseType {
+    
+    let networkClient: NetworkRequestClientType
+    
+    init(networkClient: NetworkRequestClientType) {
+        self.networkClient = networkClient
+    }
+    
+    func logout(completion: @escaping Completion) {
+            // TODO: Implement me
+    }
+    
+    
+}

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshAPITokenUseCase.swift
@@ -29,13 +29,12 @@ class RefreshAPITokenUseCase: RefreshAPITokenUseCaseType {
             } else if let dataResponse {
                 self.handleDataResponse(dataResponse, completion: completion)
             } else {
-                completion(NetworkRequestError.allConnectionAttemptsFailed)
+                completion(NetworkRequestError.allConnectionAttemptsFailed())
             }
         }
         
     }
     
-        
 }
 
 

--- a/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/RefreshVpnTokenUseCase.swift
@@ -28,7 +28,7 @@ class RefreshVpnTokenUseCase: RefreshVpnTokenUseCaseType {
             } else if let dataResponse {
                 self.handleDataResponse(dataResponse, completion: completion)
             } else {
-                completion(NetworkRequestError.allConnectionAttemptsFailed)
+                completion(NetworkRequestError.allConnectionAttemptsFailed())
             }
             
         }

--- a/Sources/PIALibrary/Common/Data/Networking/Entities/NetworkRequestError.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/Entities/NetworkRequestError.swift
@@ -2,16 +2,21 @@
 import Foundation
 
 public enum NetworkRequestError: Error, Equatable {
-    case apiTokenNotFound
-    case anchorCertificateNotFound
-    case connectionError(message: String?)
-    case allConnectionAttemptsFailed
+    case connectionError(statusCode: Int? = nil, message: String? = nil)
+    case allConnectionAttemptsFailed(statusCode: Int? = nil)
     case noDataContent
     case noErrorAndNoResponse
-    case unableToDecodeVpnToken
     case unableToSaveVpnToken
-    case unableToDecodeAPIToken
     case unableToSaveAPIToken
+    case unableToDecodeAPIToken
+    case unableToDecodeVpnToken
     case connectionCompletedWithNoResponse
-    case unknown
+    case unknown(message: String? = nil)    
+}
+
+
+enum HttpResponseStatusCode: Int {
+    case success = 200
+    case throttled = 429
+    case unauthorized = 401
 }

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
@@ -46,10 +46,11 @@ private extension NetworkRequestClient {
         var remainingConnections = connections
         let nextConnection = remainingConnections.removeFirst()
         
-        func tryNextConnectionOrFail() {
+        func tryNextConnectionOrFail(currentStatusCode: Int?) {
             if remainingConnections.isEmpty {
                 // No more endpoints to try a connection
-                completion(NetworkRequestError.allConnectionAttemptsFailed, nil)
+                let requestError = NetworkRequestError.allConnectionAttemptsFailed(statusCode: currentStatusCode)
+                completion(requestError, nil)
             } else {
                 // Continue with the next connection
                 executeRecursivelyUntilSuccess(connections: remainingConnections, completion: completion)
@@ -59,21 +60,20 @@ private extension NetworkRequestClient {
         execute(connection: nextConnection) { error, responseData in
 
             if error != nil {
-                NSLog(">>> >>> NetworkRequestClient: execute req error: \(error)")
-                tryNextConnectionOrFail()
+                tryNextConnectionOrFail(currentStatusCode: responseData?.statusCode)
             } else if let responseData {
                 let statusCode: Int = responseData.statusCode ?? -1
                 let isSuccessStatusCode = statusCode > 199 && statusCode < 300
-                NSLog(">>> >>> NetworkRequestClient: status code: \(statusCode)")
+                
                 if isSuccessStatusCode {
                     completion(nil, responseData)
                 } else {
                     // Connection did not succeed, try the next one
-                    tryNextConnectionOrFail()
+                    tryNextConnectionOrFail(currentStatusCode: responseData.statusCode)
                 }
             } else {
                 // No error and no data
-                tryNextConnectionOrFail()
+                tryNextConnectionOrFail(currentStatusCode: nil)
             }
         }
         
@@ -87,7 +87,7 @@ private extension NetworkRequestClient {
             try connection.connect { error, dataResponse in
                 if let error {
                     connectionHandled = true
-                    completion(NetworkRequestError.connectionError(message: error.localizedDescription), nil)
+                    completion(NetworkRequestError.connectionError(statusCode: dataResponse?.statusCode, message: error.localizedDescription), nil)
                 } else if let dataResponse = dataResponse as? NetworkRequestResponseType {
                     connectionHandled = true
                     completion(nil, dataResponse)
@@ -102,7 +102,7 @@ private extension NetworkRequestClient {
             }
             
         } catch {
-            completion(NetworkRequestError.connectionError(message: error.localizedDescription), nil)
+            completion(NetworkRequestError.unknown(message: error.localizedDescription), nil)
         }
     }
     

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
@@ -59,10 +59,12 @@ private extension NetworkRequestClient {
         execute(connection: nextConnection) { error, responseData in
 
             if error != nil {
+                NSLog(">>> >>> NetworkRequestClient: execute req error: \(error)")
                 tryNextConnectionOrFail()
             } else if let responseData {
                 let statusCode: Int = responseData.statusCode ?? -1
                 let isSuccessStatusCode = statusCode > 199 && statusCode < 300
+                NSLog(">>> >>> NetworkRequestClient: status code: \(statusCode)")
                 if isSuccessStatusCode {
                     completion(nil, responseData)
                 } else {

--- a/Tests/PIALibraryTests/LoginUseCaseTests.swift
+++ b/Tests/PIALibraryTests/LoginUseCaseTests.swift
@@ -1,0 +1,334 @@
+
+import XCTest
+@testable import PIALibrary
+
+class LoginUseCaseTests: XCTestCase {
+    class Fixture {
+        let networkClientMock = NetworkRequestClientMock()
+        let apiTokenProviderMock = APITokenProviderMock()
+        let refreshVpnTokenUseCaseMock = RefreshVpnTokenUseCaseMock()
+        let validApiTokenJsonString = "{\"api_token\":\"some_api_token\",\"expires_at\":\"2034-08-11T00:00:00Z\"}"
+        
+        var validApiTokenJsonData: Data!
+        let userEmail = "user@email.com"
+        var userEmailData: Data {
+            let dict = ["email": userEmail]
+            return try! JSONEncoder().encode(dict)
+        }
+        
+        init() {
+            validApiTokenJsonData = validApiTokenJsonString.data(using: .utf8)
+        }
+        
+        let credentials = Credentials(username: "username", password: "password")
+        
+        var credentialsBodyData: Data {
+            let credsDict = credentials.toJSONDictionary() as! [String: String]
+            
+            return try! JSONEncoder().encode(credsDict)
+        }
+        
+        let receiptData = Data()
+        var receiptBodyData: Data {
+            let receiptDict = ["receipt": receiptData.base64EncodedString()]
+            
+            return try! JSONEncoder().encode(receiptDict)
+        }
+        
+        
+        func stubLoginSuccessfulResponse() {
+            let successResponse = NetworkRequestResponseMock(statusCode: 200, data: validApiTokenJsonData)
+           
+            networkClientMock.executeRequestResponse = successResponse
+        }
+        
+        func stubLoginFailedResponseWith401() {
+            let response = NetworkRequestResponseMock(statusCode: 401)
+            networkClientMock.executeRequestResponse = response
+        }
+        
+        func stubLoginFailedResponseWithError() {
+            networkClientMock.executeRequestError = .connectionError(statusCode: 500)
+        }
+        
+        func stubFailSavingApiToken() {
+            apiTokenProviderMock.saveAPITokenFromDataError = NetworkRequestError.unableToSaveAPIToken
+        }
+        
+        func stubLoginLinkSuccessfulResponse() {
+            let successResponse = NetworkRequestResponseMock(statusCode: 200)
+           
+            networkClientMock.executeRequestResponse = successResponse
+        }
+        
+    }
+    
+    var fixture: Fixture!
+    var sut: LoginUseCase!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = LoginUseCase(networkClient: fixture.networkClientMock, apiTokenProvider: fixture.apiTokenProviderMock, refreshVpnTokenUseCase: fixture.refreshVpnTokenUseCaseMock)
+    }
+    
+    func testLoginWithCredentialsWhenRequestSucceeds() {
+        // GIVEN that the network request to login with creds succeeds
+        fixture.stubLoginSuccessfulResponse()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login with Creds
+        sut.login(with: fixture.credentials) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.login)
+        
+        // WITH the username and password encoded in the body of the request
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.body?.count, fixture.credentialsBodyData.count)
+        
+        // AND the API token from the response is stored
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 1)
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledWithArg, fixture.validApiTokenJsonData)
+        
+        // AND the Vpn token is refreshed after login
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+        
+    }
+    
+    func testLoginWithCredentialsWhenResponseFailsWith401() {
+        // GIVEN that the network request to login with creds fails with status code 401
+        fixture.stubLoginFailedResponseWith401()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login with Creds
+        sut.login(with: fixture.credentials) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.login)
+        
+        // AND the API token provider is NOT called to save anything
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 0)
+        
+        // AND the Vpn token is NOT refreshed
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testLoginWithCredentialsWhenResponseFailsWithServerError() {
+        // GIVEN that the network request to login with creds fails with server error
+        fixture.stubLoginFailedResponseWithError()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login with Creds
+        sut.login(with: fixture.credentials) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.login)
+        
+        // AND the API token provider is NOT called to save anything
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 0)
+        
+        // AND the Vpn token is NOT refreshed
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testLoginWithReceiptWhenRequestSucceeds() {
+        // GIVEN that the network request to login with receipt succeeds
+        fixture.stubLoginSuccessfulResponse()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login with receipt
+        sut.login(with: fixture.receiptData.base64EncodedString()) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.login)
+        
+        // WITH the receipt encoded in the body of the request
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.body?.count, fixture.receiptBodyData.count)
+        
+        // AND the API token from the response is stored
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 1)
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledWithArg, fixture.validApiTokenJsonData)
+        
+        // AND the Vpn token is refreshed after login
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+        
+    }
+    
+    func testLoginWithReceiptWhenResponseFailsWith401() {
+        // GIVEN that the network request to login with receipt fails with status code 401
+        fixture.stubLoginFailedResponseWith401()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login with Receipt
+        sut.login(with: fixture.receiptData.base64EncodedString()) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.login)
+        
+        // AND the API token provider is NOT called to save anything
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 0)
+        // AND the Vpn token is NOT refreshed
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testLoginWithReceiptWhenResponseFailsWithServerError() {
+        // GIVEN that the network request to login with receipt fails with server error
+        fixture.stubLoginFailedResponseWithError()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login with Creds
+        sut.login(with: fixture.receiptData.base64EncodedString()) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.login)
+        
+        // AND the API token provider is NOT called to save anything
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 0)
+        // AND the Vpn token is NOT refreshed
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    func testLoginLinkWhenRequestSucceeds() {
+        // GIVEN that the network request to login link succeeds
+        fixture.stubLoginLinkSuccessfulResponse()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login link with email
+        sut.loginLink(with: fixture.userEmail) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        // THEN the login link request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.loginLink)
+        
+        // WITH the email encoded in the body of the request
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.body?.count, fixture.userEmailData.count)
+        
+        // AND the API token provider is not called to store anything
+        XCTAssertEqual(fixture.apiTokenProviderMock.saveAPITokenFromDataCalledAttempt, 0)
+
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+        
+    }
+    
+    
+    func testLoginLinkWhenResponseFails() {
+        // GIVEN that the network request to login link fails
+        fixture.stubLoginFailedResponseWithError()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Login call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN login link with email
+        sut.loginLink(with: fixture.userEmail) { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
+        // THEN the login link request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.loginLink)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        wait(for: [expectation], timeout: 3)
+    }
+    
+    
+}

--- a/Tests/PIALibraryTests/Mocks/APITokenProviderMock.swift
+++ b/Tests/PIALibraryTests/Mocks/APITokenProviderMock.swift
@@ -20,8 +20,12 @@ class APITokenProviderMock: APITokenProviderType {
     
     var saveAPITokenFromDataCalledAttempt = 0
     var saveAPITokenFromDataCalledWithArg: Data?
+    var saveAPITokenFromDataError: NetworkRequestError? = nil
     func saveAPIToken(from data: Data) throws {
         saveAPITokenFromDataCalledAttempt += 1
         saveAPITokenFromDataCalledWithArg = data
+        if let saveAPITokenFromDataError {
+            throw saveAPITokenFromDataError
+        }
     }
 }

--- a/Tests/PIALibraryTests/Mocks/File.swift
+++ b/Tests/PIALibraryTests/Mocks/File.swift
@@ -9,9 +9,10 @@ class NetworkRequestClientMock: NetworkRequestClientType {
     var executeRequestCalledAttempt = 0
     var executeRequestError: NetworkRequestError?
     var executeRequestResponse: NetworkRequestResponseType?
-    
+    var executeRequestWithConfiguation: NetworkRequestConfigurationType?
     func executeRequest(with configuration: NetworkRequestConfigurationType, completion: @escaping Completion) {
         executeRequestCalledAttempt += 1
+        executeRequestWithConfiguation = configuration
         completion(executeRequestError, executeRequestResponse)
     }
 }

--- a/Tests/PIALibraryTests/Mocks/VpnTokenProviderMock.swift
+++ b/Tests/PIALibraryTests/Mocks/VpnTokenProviderMock.swift
@@ -19,9 +19,13 @@ class VpnTokenProviderMock: VpnTokenProviderType {
     
     var saveVpnTokenFromDataCalledAttempt = 0
     var saveVpnTokenFromDataCalledWithArg: Data?
+    var saveVpnTokenFromDataError: NetworkRequestError?
     func saveVpnToken(from data: Data) throws {
         saveVpnTokenFromDataCalledAttempt += 1
         saveVpnTokenFromDataCalledWithArg = data
+        if let saveVpnTokenFromDataError {
+            throw saveVpnTokenFromDataError
+        }
     }
 }
 

--- a/Tests/PIALibraryTests/NetworkRequestClientTests.swift
+++ b/Tests/PIALibraryTests/NetworkRequestClientTests.swift
@@ -25,7 +25,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         func makeFailedConnectionWithErrorAndNoResponse() -> NWHttpConnectionMock {
             let failConnectionWithNoResponse = NWHttpConnectionMock()
-            failConnectionWithNoResponse.connectionError = NWHttpConnectionError.unknown(NetworkRequestError.unknown)
+            failConnectionWithNoResponse.connectionError = NWHttpConnectionError.unknown(NetworkRequestError.unknown(message: "unknown error"))
             failConnectionWithNoResponse.connectionResponse = nil
             return failConnectionWithNoResponse
             
@@ -179,7 +179,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         // AND an error is returned
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, NetworkRequestError.allConnectionAttemptsFailed)
+        XCTAssertEqual(capturedError!, NetworkRequestError.allConnectionAttemptsFailed(statusCode: 401))
         
         // AND a response is not returned
         XCTAssertNil(capturedResponse)
@@ -216,7 +216,7 @@ class NetworkRequestClientTests: XCTestCase {
         
         // AND an error is returned
         XCTAssertNotNil(capturedError)
-        XCTAssertEqual(capturedError!, NetworkRequestError.allConnectionAttemptsFailed)
+        XCTAssertEqual(capturedError!, NetworkRequestError.allConnectionAttemptsFailed())
         
         // AND a response is not returned
         XCTAssertNil(capturedResponse)

--- a/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
+++ b/Tests/PIALibraryTests/RefreshAuthTokensCheckerTests.swift
@@ -84,7 +84,7 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         fixture.stubVpnToken(with: fixture.expirationDateIn10Days)
         
         // AND GIVEN that refreshing the API token request fails
-        fixture.stubRefreshAPIToken(with: .apiTokenNotFound)
+        fixture.stubRefreshAPIToken(with: .unableToSaveAPIToken)
         
         instantiateSut()
         


### PR DESCRIPTION
This PR contains the `LoginUseCase` that performs the following requests:
- Login with credentials
- Login with receipt
- Request a login link via email

Note:
There is a utility struct `ClientErrorMapper` that maps the `NetworkRequestError` to a `ClientError` (the one that the app is expecting). This struct is not used anywhere yet. The idea is to use it on the `PIAWebServices` layer. But I would like to get some feedback so far about it.