### PR TITLE
PIA-1849: Migrate update account APIs

### DIFF
--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -19,9 +19,14 @@ public class AccountFactory {
         SignupUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), 
                       signupInformationDataCoverter: SignupInformationDataCoverter())
     }
+
+    public static func makeUpdateAccountUseCase() -> UpdateAccountUseCaseType {
+        UpdateAccountUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), refreshAuthTokensChecker: makeRefreshAuthTokensChecker())
+    }
     
     static func makeDefaultAccountProvider(with webServices: WebServices? = nil) -> DefaultAccountProvider {
-        DefaultAccountProvider(webServices: webServices, logoutUseCase: makeLogoutUseCase(), loginUseCase: makeLoginUseCase(), signupUseCase: makeSignupUseCase(), apiTokenProvider: makeAPITokenProvider(), vpnTokenProvider: makeVpnTokenProvider(), accountDetailsUseCase: makeAccountDetailsUseCase())
+        DefaultAccountProvider(webServices: webServices, logoutUseCase: makeLogoutUseCase(), loginUseCase: makeLoginUseCase(), signupUseCase: makeSignupUseCase(), apiTokenProvider: makeAPITokenProvider(), vpnTokenProvider: makeVpnTokenProvider(), accountDetailsUseCase: makeAccountDetailsUseCase(), updateAccountUseCase: makeUpdateAccountUseCase())
+
     }
     
     static func makeRefreshAPITokenUseCase() -> RefreshAPITokenUseCaseType {

--- a/Sources/PIALibrary/Account/Data/Networking/AccountDetailsRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/AccountDetailsRequestConfiguration.swift
@@ -12,7 +12,10 @@ struct AccountDetailsRequestConfiguration: NetworkRequestConfigurationType {
     let inlcudeAuthHeaders: Bool = true
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
+    
+    var otherHeaders: [String : String]? = nil
     var body: Data? = nil
+    
     let timeout: TimeInterval = 10
     let requestQueue: DispatchQueue? = DispatchQueue(label: "accountDetails_request.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/LoginLinkRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/LoginLinkRequestConfiguration.swift
@@ -12,7 +12,10 @@ struct LoginLinkRequestConfiguration: NetworkRequestConfigurationType {
     let inlcudeAuthHeaders: Bool = false
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
+    
     var body: Data? = nil
+    var otherHeaders: [String : String]? = nil
+    
     let timeout: TimeInterval = 10
     let requestQueue: DispatchQueue? = DispatchQueue(label: "login_request.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/LoginRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/LoginRequestConfiguration.swift
@@ -12,7 +12,10 @@ struct LoginRequestConfiguration: NetworkRequestConfigurationType {
     let inlcudeAuthHeaders: Bool = false
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
+    
     var body: Data? = nil
+    var otherHeaders: [String : String]? = nil
+    
     let timeout: TimeInterval = 10
     let requestQueue: DispatchQueue? = DispatchQueue(label: "login_request.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/RefreshApiTokenRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/RefreshApiTokenRequestConfiguration.swift
@@ -10,7 +10,10 @@ struct RefreshApiTokenRequestConfiguration: NetworkRequestConfigurationType {
     let inlcudeAuthHeaders: Bool = true
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
+    
     let body: Data? = nil
+    var otherHeaders: [String : String]? = nil
+    
     let timeout: TimeInterval = 10
     let requestQueue: DispatchQueue? = DispatchQueue(label: "refresh.api_token.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/RefreshVpnTokenRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/RefreshVpnTokenRequestConfiguration.swift
@@ -10,7 +10,10 @@ struct RefreshVpnTokenRequestConfiguration: NetworkRequestConfigurationType {
     let inlcudeAuthHeaders: Bool = true
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
+    
     let body: Data? = nil
+    var otherHeaders: [String : String]? = nil
+    
     let timeout: TimeInterval = 10
     let requestQueue: DispatchQueue? = DispatchQueue(label: "refresh.vpn_token.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/SignupRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/SignupRequestConfiguration.swift
@@ -13,7 +13,10 @@ struct SignupRequestConfiguration: NetworkRequestConfigurationType {
     var contentType: NetworkRequestContentType = .json
     let urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
+    
     var body: Data? = nil
+    var otherHeaders: [String : String]? = nil
+    
     let timeout: TimeInterval = 10
     let requestQueue: DispatchQueue? = DispatchQueue(label: "signup.queue")
 }

--- a/Sources/PIALibrary/Account/Data/Networking/UpdateAccountRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/UpdateAccountRequestConfiguration.swift
@@ -1,21 +1,21 @@
 
-
 import Foundation
 import NWHttpConnection
 
-struct LogoutRequestConfiguration: NetworkRequestConfigurationType {
+struct UpdateAccountRequestConfiguration: NetworkRequestConfigurationType {
     
     let networkRequestModule: NetworkRequestModule = .account
-    let path: RequestAPI.Path = .logout
+    let path: RequestAPI.Path = .setEmail
     let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .post
     let contentType: NetworkRequestContentType = .json
-    let inlcudeAuthHeaders: Bool = true
-    let urlQueryParameters: [String : String]? = nil
+    var inlcudeAuthHeaders: Bool = true
+    var urlQueryParameters: [String : String]? = nil
     let responseDataType: NWDataResponseType = .jsonData
     
     var body: Data? = nil
     var otherHeaders: [String : String]? = nil
     
     let timeout: TimeInterval = 10
-    let requestQueue: DispatchQueue? = DispatchQueue(label: "logout_request.queue")
+    let requestQueue: DispatchQueue? = DispatchQueue(label: "updateAccount_request.queue")
 }
+

--- a/Sources/PIALibrary/Account/Domain/UseCases/LogoutUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/LogoutUseCase.swift
@@ -25,7 +25,7 @@ class LogoutUseCase: LogoutUseCaseType {
         
         refreshAuthTokensChecker.refreshIfNeeded { [weak self] refreshTokensError in
             guard let self else { return }
-            
+           
             self.networkClient.executeRequest(with: requestConfiguration) { error, response in
                 self.clearAuthTokens(with: completion)
             }

--- a/Sources/PIALibrary/Account/Domain/UseCases/UpdateAccountUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/UpdateAccountUseCase.swift
@@ -1,0 +1,24 @@
+
+import Foundation
+
+protocol UpdateAccountUseCaseType {
+    typealias Completion = ((Result<String, NetworkRequestError>) -> Void)
+    
+    func setEmail(email: String, resetPassword: Bool, completion: @escaping Completion)
+    
+    func setEmail(username: String, password: String, email: String, resetPassword: Bool, completion: @escaping Completion)
+}
+
+
+class UpdateAccountUseCase: UpdateAccountUseCaseType {
+    
+    func setEmail(email: String, resetPassword: Bool, completion: @escaping Completion) {
+        
+    }
+    
+    func setEmail(username: String, password: String, email: String, resetPassword: Bool, completion: @escaping Completion) {
+        
+    }
+    
+    
+}

--- a/Sources/PIALibrary/Account/Domain/UseCases/UpdateAccountUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/UpdateAccountUseCase.swift
@@ -1,8 +1,8 @@
 
 import Foundation
 
-protocol UpdateAccountUseCaseType {
-    typealias Completion = ((Result<String, NetworkRequestError>) -> Void)
+public protocol UpdateAccountUseCaseType {
+    typealias Completion = ((Result<String?, NetworkRequestError>) -> Void)
     
     func setEmail(email: String, resetPassword: Bool, completion: @escaping Completion)
     
@@ -12,13 +12,90 @@ protocol UpdateAccountUseCaseType {
 
 class UpdateAccountUseCase: UpdateAccountUseCaseType {
     
+    private let networkClient: NetworkRequestClientType
+    private let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
+    
+    init(networkClient: NetworkRequestClientType, refreshAuthTokensChecker: RefreshAuthTokensCheckerType) {
+        self.networkClient = networkClient
+        self.refreshAuthTokensChecker = refreshAuthTokensChecker
+    }
+    
+    
     func setEmail(email: String, resetPassword: Bool, completion: @escaping Completion) {
         
+        refreshAuthTokensChecker.refreshIfNeeded { error in
+            if let error {
+                completion(.failure(error))
+            } else {
+                var configuration = UpdateAccountRequestConfiguration()
+               
+                let bodyDataDict: [String: String] = [
+                    "email": email,
+                    "reset_password": resetPassword.toString()
+                ]
+                
+                if let bodyData = try? JSONEncoder().encode(bodyDataDict) {
+                    configuration.body = bodyData
+                }
+                
+                self.executeNetworkRequest(with: configuration, completion: completion)
+            }
+        }
     }
     
     func setEmail(username: String, password: String, email: String, resetPassword: Bool, completion: @escaping Completion) {
         
+        refreshAuthTokensChecker.refreshIfNeeded { error in
+            if let error {
+                completion(.failure(error))
+            } else {
+                var configuration = UpdateAccountRequestConfiguration()
+                
+                configuration.inlcudeAuthHeaders = false
+                
+                if let authHeatherValue = "\(username):\(password)".toBase64() {
+                    configuration.otherHeaders = ["Authorization": "Basic \(authHeatherValue)"]
+                }
+                
+                let queryParameters: [String: String] = [
+                    "email": email,
+                    "reset_password": resetPassword.toString()
+                ]
+                
+                configuration.urlQueryParameters = queryParameters
+                
+                self.executeNetworkRequest(with: configuration, completion: completion)
+            }
+        }
     }
     
     
 }
+
+private extension UpdateAccountUseCase {
+    
+    func executeNetworkRequest(with configuration: NetworkRequestConfigurationType, completion: @escaping Completion) {
+        
+        networkClient.executeRequest(with: configuration) { error, dataResponse in
+            
+            if let error {
+                completion(.failure(error))
+            } else {
+                guard let data = dataResponse?.data else {
+                    completion(.failure(.noDataContent))
+                    return
+                }
+                
+                let decodedResponse = try?   JSONDecoder().decode([String:String].self, from: data)
+                
+                let tempPassword = decodedResponse?["password"]
+                completion(.success(tempPassword))
+                
+            }
+        }
+        
+    }
+    
+}
+
+

--- a/Sources/PIALibrary/Common/Data/Extensions/Bool+Extensions.swift
+++ b/Sources/PIALibrary/Common/Data/Extensions/Bool+Extensions.swift
@@ -1,0 +1,14 @@
+
+import Foundation
+
+extension Bool {
+    func toString() -> String {
+        switch self {
+        case true:
+            return "true"
+        case false:
+            return "false"
+        }
+    }
+}
+

--- a/Sources/PIALibrary/Common/Data/Extensions/String+Extensions.swift
+++ b/Sources/PIALibrary/Common/Data/Extensions/String+Extensions.swift
@@ -1,0 +1,20 @@
+
+import Foundation
+
+extension String {
+    func fromBase64() -> String? {
+        guard let data = Data(base64Encoded: self, options: Data.Base64DecodingOptions(rawValue: 0)) else {
+            return nil
+        }
+        
+        return String(data: data as Data, encoding: String.Encoding.utf8)
+    }
+    
+    func toBase64() -> String? {
+        guard let data = self.data(using: String.Encoding.utf8) else {
+            return nil
+        }
+        
+        return data.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
+    }
+}

--- a/Sources/PIALibrary/Common/Data/Networking/Interfaces/NetworkRequestConfigurationType.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/Interfaces/NetworkRequestConfigurationType.swift
@@ -18,6 +18,7 @@ protocol NetworkRequestConfigurationType {
     var path: RequestAPI.Path { get }
     var httpMethod: NWConnectionHTTPMethod { get }
     var inlcudeAuthHeaders: Bool { get }
+    var otherHeaders: [String: String]? { get }
     var contentType: NetworkRequestContentType { get }
     var urlQueryParameters: [String: String]? { get }
     var responseDataType: NWDataResponseType { get }

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkConnectionRequestProvider.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkConnectionRequestProvider.swift
@@ -24,7 +24,6 @@ class NetworkConnectionRequestProvider: NetworkConnectionRequestProviderType {
         guard let requestURL = networkRequestURLProvider.getURL(for: endpoint, path: configuration.path, query: configuration.urlQueryParameters) else {
             return nil
         }
-
         
         guard let anchorCertificate = AnchorCertificateProvider.getAnchorCertificate() else {
             return nil
@@ -40,6 +39,10 @@ class NetworkConnectionRequestProvider: NetworkConnectionRequestProviderType {
                 return nil
             }
             headers["Authorization"] = "Token \(apiToken.apiToken)"
+        }
+        
+        if let otherHeaders = configuration.otherHeaders {
+            headers.merge(otherHeaders) { $1 }
         }
         
         let connectionConfiguration = NWConnectionConfiguration(url: requestURL, method: configuration.httpMethod, headers: headers, body: configuration.body, certificateValidation: makeCertificateValidation(for: endpoint, anchorCertificate: anchorCertificate), dataResponseType: configuration.responseDataType, timeout: configuration.timeout, queue: configuration.requestQueue)

--- a/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -185,24 +185,6 @@ class PIAWebServices: WebServices, ConfigurationAccess {
     private func mapAccountDetailsError(_ error:AccountRequestError) -> ClientError {
         return mapLoginLinkError(error)
     }
-
-//    func info(_ callback: ((AccountInfo?, Error?) -> Void)?) {
-//        
-//        self.accountAPI.accountDetails() { [weak self] (response, errors) in
-//            
-//            if !errors.isEmpty {
-//                callback?(nil, self?.mapAccountDetailsError(errors.last!))
-//                return
-//            }
-//
-//            if let response = response {
-//                let account = AccountInfo(accountInformation: response)
-//                callback?(account, nil)
-//            } else {
-//                callback?(nil, ClientError.malformedResponseData)
-//            }
-//        }
-//    }
     
     func update(credentials: Credentials, resetPassword reset: Bool, email: String, _ callback: SuccessLibraryCallback?) {
         if reset {

--- a/Tests/PIALibraryTests/Accounts/UpdateAccountUseCaseTests.swift
+++ b/Tests/PIALibraryTests/Accounts/UpdateAccountUseCaseTests.swift
@@ -1,0 +1,392 @@
+
+import XCTest
+@testable import PIALibrary
+
+class UpdateAccountUseCaseTests: XCTestCase {
+    class Fixture {
+        let networkClientMock = NetworkRequestClientMock()
+        let refreshAuthTokenCheckerMock = RefreshAuthTokensCheckerMock()
+        let tempPassword = "TempPass123"
+        
+        func stubRefreshAuthTokenWithError(error: NetworkRequestError) {
+            refreshAuthTokenCheckerMock.refreshIfNeededError = error
+        }
+        
+        func stubUpdateAccountSuccessfulResponseWith(temporaryPassword: Bool) {
+            var successResponseDict = ["status": "success"]
+            
+            if temporaryPassword {
+                successResponseDict["password"] = tempPassword
+            }
+            
+            let successResponseDictData = try! JSONEncoder().encode(successResponseDict)
+            let successfulResponse = NetworkRequestResponseMock(statusCode: 200, data: successResponseDictData)
+            
+            networkClientMock.executeRequestResponse = successfulResponse
+        }
+        
+        func stubUpdateAccountResponseWithNoData() {
+            let successfulResponse = NetworkRequestResponseMock(statusCode: 200, data: nil)
+            
+            networkClientMock.executeRequestResponse = successfulResponse
+        }
+        
+        
+        func stubUpdateAccountWithError(error: NetworkRequestError) {
+            networkClientMock.executeRequestError = error
+        }
+    }
+    
+    var fixture: Fixture!
+    var sut: UpdateAccountUseCase!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = UpdateAccountUseCase(networkClient: fixture.networkClientMock, refreshAuthTokensChecker: fixture.refreshAuthTokenCheckerMock)
+    }
+    
+    func test_updateAccountWithoutResetPassword_when_response_is_successful() {
+        // GIVEN that update account without reseting password succeeds
+        fixture.stubUpdateAccountSuccessfulResponseWith(temporaryPassword: false)
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account
+        sut.setEmail(username: "user", password: "pass", email: "email@mail.com", resetPassword: false) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens are refeshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation!
+        
+        // AND the `setEmail` request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(executedRequestConfiguration.path, RequestAPI.Path.setEmail)
+        // WITH the correct url query parameters
+        XCTAssertEqual(executedRequestConfiguration.urlQueryParameters, ["email": "email@mail.com", "reset_password": "false"])
+        
+        let userPassToBase64 = "user:pass".toBase64()!
+        let otherHeaders = ["Authorization": "Basic \(userPassToBase64)"]
+        
+        // AND the Basic Authorization Header
+        XCTAssertEqual(executedRequestConfiguration.otherHeaders!, otherHeaders)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        // AND no new password is returned
+        XCTAssertNil(capturedNewPassword)
+        
+    }
+    
+    
+    func test_updateAccountWithoutResetPassword_when_request_returns_error() {
+        // GIVEN that update account without reseting password returns an error
+        fixture.stubUpdateAccountWithError(error: .allConnectionAttemptsFailed(statusCode: 401))
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account
+        sut.setEmail(username: "user", password: "pass", email: "email@mail.com", resetPassword: false) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens are refeshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation!
+        
+        // AND the `setEmail` request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(executedRequestConfiguration.path, RequestAPI.Path.setEmail)
+        // WITH the correct url query parameters
+        XCTAssertEqual(executedRequestConfiguration.urlQueryParameters, ["email": "email@mail.com", "reset_password": "false"])
+        
+        let userPassToBase64 = "user:pass".toBase64()!
+        let otherHeaders = ["Authorization": "Basic \(userPassToBase64)"]
+        
+        // AND the Basic Authorization Header
+        XCTAssertEqual(executedRequestConfiguration.otherHeaders!, otherHeaders)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .allConnectionAttemptsFailed(statusCode: 401))
+        
+        // AND no new password is returned
+        XCTAssertNil(capturedNewPassword)
+        
+    }
+    
+    func test_updateAccountWithoutResetPassword_when_refreshingTokensFail() {
+        // GIVEN that refreshing tokens fail
+        fixture.stubRefreshAuthTokenWithError(error: .allConnectionAttemptsFailed(statusCode: 401))
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account
+        sut.setEmail(username: "user", password: "pass", email: "email@mail.com", resetPassword: false) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens request is executed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation
+        
+        // AND the `setEmail` request is NOT executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 0)
+        XCTAssertNil(executedRequestConfiguration)
+       
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .allConnectionAttemptsFailed(statusCode: 401))
+        
+        // AND no new password is returned
+        XCTAssertNil(capturedNewPassword)
+        
+    }
+    
+    func test_updateAccountWithoutResetPassword_when_request_returns_noData() {
+        // GIVEN that update account without reseting password returns no data
+        fixture.stubUpdateAccountResponseWithNoData()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account
+        sut.setEmail(username: "user", password: "pass", email: "email@mail.com", resetPassword: false) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens are refeshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation!
+        
+        // AND the `setEmail` request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(executedRequestConfiguration.path, RequestAPI.Path.setEmail)
+        // WITH the correct url query parameters
+        XCTAssertEqual(executedRequestConfiguration.urlQueryParameters, ["email": "email@mail.com", "reset_password": "false"])
+        
+        let userPassToBase64 = "user:pass".toBase64()!
+        let otherHeaders = ["Authorization": "Basic \(userPassToBase64)"]
+        
+        // AND the Basic Authorization Header
+        XCTAssertEqual(executedRequestConfiguration.otherHeaders!, otherHeaders)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .noDataContent)
+        
+        // AND no new password is returned
+        XCTAssertNil(capturedNewPassword)
+        
+    }
+    
+    func test_updateAccountWithResetPassword_when_response_is_successful() {
+        // GIVEN that update account with reseting password succeeds
+        fixture.stubUpdateAccountSuccessfulResponseWith(temporaryPassword: true)
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account with reset password
+        sut.setEmail(email: "email@mail.com", resetPassword: true) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens are refeshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation!
+        
+        // AND the `setEmail` request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(executedRequestConfiguration.path, RequestAPI.Path.setEmail)
+        // WITH the correct body Data
+        let submittedBody = ["email": "email@mail.com", "reset_password": "true"]
+        let submittedBodyData = try! JSONEncoder().encode(submittedBody)
+        XCTAssertEqual(executedRequestConfiguration.body!.count, submittedBodyData.count)
+        // AND the Token Authorization Header
+        XCTAssertTrue(executedRequestConfiguration.inlcudeAuthHeaders)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+        
+        // AND a new password is returned
+        XCTAssertEqual(capturedNewPassword, fixture.tempPassword)
+        
+    }
+    
+    
+    func test_updateAccountWithResetPassword_when_request_returns_error() {
+        // GIVEN that update account without reseting password returns an error
+        fixture.stubUpdateAccountWithError(error: .allConnectionAttemptsFailed(statusCode: 401))
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account with reset password
+        sut.setEmail(email: "email@mail.com", resetPassword: true) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens are refeshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation!
+        
+        // AND the `setEmail` request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(executedRequestConfiguration.path, RequestAPI.Path.setEmail)
+        // WITH the correct body Data
+        let submittedBody = ["email": "email@mail.com", "reset_password": "true"]
+        let submittedBodyData = try! JSONEncoder().encode(submittedBody)
+        XCTAssertEqual(executedRequestConfiguration.body!.count, submittedBodyData.count)
+        
+        // AND the Token Authorization Header
+        XCTAssertTrue(executedRequestConfiguration.inlcudeAuthHeaders)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .allConnectionAttemptsFailed(statusCode: 401))
+        
+        // AND no new password is returned
+        XCTAssertNil(capturedNewPassword)
+        
+    }
+    
+    func test_updateAccountWithResetPassword_when_refreshingTokensFail() {
+        // GIVEN that refreshing tokens fail
+        fixture.stubRefreshAuthTokenWithError(error: .allConnectionAttemptsFailed(statusCode: 401))
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Update account request executed")
+        var capturedError: NetworkRequestError?
+        var capturedNewPassword: String?
+        
+        // WHEN updating the account with reset password
+        sut.setEmail(email: "email@mail.com", resetPassword: true) { result in
+            
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let newPassword):
+                capturedNewPassword = newPassword
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the auth tokens request is executed
+        XCTAssertEqual(fixture.refreshAuthTokenCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        let executedRequestConfiguration = fixture.networkClientMock.executeRequestWithConfiguation
+        
+        // AND the `setEmail` request is NOT executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 0)
+        XCTAssertNil(executedRequestConfiguration)
+       
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .allConnectionAttemptsFailed(statusCode: 401))
+        
+        // AND no new password is returned
+        XCTAssertNil(capturedNewPassword)
+        
+    }
+    
+}

--- a/Tests/PIALibraryTests/Mocks/NetworkRequestConfigurationMock.swift
+++ b/Tests/PIALibraryTests/Mocks/NetworkRequestConfigurationMock.swift
@@ -14,6 +14,7 @@ struct NetworkRequestConfigurationMock: NetworkRequestConfigurationType {
     var urlQueryParameters: [String : String]? = nil
     var responseDataType: NWHttpConnection.NWDataResponseType = .jsonData
     var body: Data? = nil
+    var otherHeaders: [String : String]? = nil
     var timeout: TimeInterval = 1
     var requestQueue: DispatchQueue? = nil
     


### PR DESCRIPTION
- Update account APIs (setEmail) with the option of reseting or not the password
- Added the optional `otherHeathers` property in `NetworkRequestConfigurationType` since one of the APIs to update account details requires the option to set another header for basic authentication
- Added unit tests to `UpdateAccountDetailsUseCase`