### PR TITLE
PIA-1844: Migrate client status API to native

### DIFF
--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -49,6 +49,10 @@ public class AccountFactory {
     static func makeRefreshAuthTokensChecker() -> RefreshAuthTokensCheckerType {
         RefreshAuthTokensChecker(apiTokenProvider: makeAPITokenProvider(), vpnTokenProvier: makeVpnTokenProvider(), refreshAPITokenUseCase: makeRefreshAPITokenUseCase(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
     }
+    
+    public static func makeClientStatusUseCase() -> ClientStatusUseCaseType {
+        ClientStatusUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), refreshAuthTokensChecker: makeRefreshAuthTokensChecker(), clientStatusDecoder: makeClientStatusInfoDecoder())
+    }
 }
 
 // MARK: - Private
@@ -77,6 +81,10 @@ private extension AccountFactory {
     
     static func makeAccountInfoDecoder() -> AccountInfoDecoderType {
         AccountInfoDecoder()
+    }
+    
+    static func makeClientStatusInfoDecoder() -> ClientStatusInformationDecoderType {
+        ClientStatusInformationDecoder()
     }
     
 }

--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -16,17 +16,17 @@ public class AccountFactory {
     }
     
     public static func makeSignupUseCase() -> SignupUseCaseType {
-        SignupUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), 
+        SignupUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(),
                       signupInformationDataCoverter: SignupInformationDataCoverter())
     }
-
+    
     public static func makeUpdateAccountUseCase() -> UpdateAccountUseCaseType {
         UpdateAccountUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), refreshAuthTokensChecker: makeRefreshAuthTokensChecker())
     }
     
     static func makeDefaultAccountProvider(with webServices: WebServices? = nil) -> DefaultAccountProvider {
         DefaultAccountProvider(webServices: webServices, logoutUseCase: makeLogoutUseCase(), loginUseCase: makeLoginUseCase(), signupUseCase: makeSignupUseCase(), apiTokenProvider: makeAPITokenProvider(), vpnTokenProvider: makeVpnTokenProvider(), accountDetailsUseCase: makeAccountDetailsUseCase(), updateAccountUseCase: makeUpdateAccountUseCase())
-
+        
     }
     
     static func makeRefreshAPITokenUseCase() -> RefreshAPITokenUseCaseType {
@@ -47,7 +47,7 @@ public class AccountFactory {
     }
     
     static func makeRefreshAuthTokensChecker() -> RefreshAuthTokensCheckerType {
-        RefreshAuthTokensChecker(apiTokenProvider: makeAPITokenProvider(), vpnTokenProvier: makeVpnTokenProvider(), refreshAPITokenUseCase: makeRefreshAPITokenUseCase(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
+        refreshAuthTokensCheckerShared
     }
     
     public static func makeClientStatusUseCase() -> ClientStatusUseCaseType {
@@ -69,6 +69,10 @@ private extension AccountFactory {
     
     static var secureStoreShared: SecureStore = {
         KeychainStore(team: Client.Configuration.teamId, group: Client.Configuration.appGroup)
+    }()
+    
+    static var refreshAuthTokensCheckerShared: RefreshAuthTokensCheckerType = {
+        RefreshAuthTokensChecker(apiTokenProvider: makeAPITokenProvider(), vpnTokenProvier: makeVpnTokenProvider(), refreshAPITokenUseCase: makeRefreshAPITokenUseCase(), refreshVpnTokenUseCase: makeRefreshVpnTokenUseCase())
     }()
     
     static func makeSecureStore() -> SecureStore {

--- a/Sources/PIALibrary/Account/Data/ClientErrorMapper.swift
+++ b/Sources/PIALibrary/Account/Data/ClientErrorMapper.swift
@@ -39,6 +39,9 @@ struct ClientErrorMapper {
             
         case .badReceipt:
             return .badReceipt
+            
+        case .unableToDecodeData:
+            return .malformedResponseData
         }
     }
     

--- a/Sources/PIALibrary/Account/Data/ClientStatusInformationDecoder.swift
+++ b/Sources/PIALibrary/Account/Data/ClientStatusInformationDecoder.swift
@@ -1,0 +1,15 @@
+
+import Foundation
+
+protocol ClientStatusInformationDecoderType {
+    func decodeClientStatus(from data: Data) -> ClientStatusInformation?
+}
+
+class ClientStatusInformationDecoder: ClientStatusInformationDecoderType {
+    
+    private let jsonDecoder = JSONDecoder()
+    
+    func decodeClientStatus(from data: Data) -> ClientStatusInformation? {
+        try? jsonDecoder.decode(ClientStatusInformation.self, from: data)
+    }
+}

--- a/Sources/PIALibrary/Account/Data/Networking/ClientStatusRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/ClientStatusRequestConfiguration.swift
@@ -1,0 +1,23 @@
+
+
+import Foundation
+import NWHttpConnection
+
+struct ClientStatusRequestConfiguration: NetworkRequestConfigurationType {
+    
+    let networkRequestModule: NetworkRequestModule = .account
+    let path: RequestAPI.Path = .clientStatus
+    let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .get
+    let contentType: NetworkRequestContentType = .json
+    let inlcudeAuthHeaders: Bool = false
+    let urlQueryParameters: [String : String]? = nil
+    let responseDataType: NWDataResponseType = .jsonData
+    
+    var otherHeaders: [String : String]? = nil
+    var body: Data? = nil
+    
+    let timeout: TimeInterval = 10
+    let requestQueue: DispatchQueue? = DispatchQueue(label: "clientStatus_request.queue")
+}
+
+

--- a/Sources/PIALibrary/Account/Domain/Entities/File.swift
+++ b/Sources/PIALibrary/Account/Domain/Entities/File.swift
@@ -1,0 +1,7 @@
+
+import Foundation
+
+public struct ClientStatusInformation: Codable, Equatable {
+    let connected: Bool
+    let ip: String
+}

--- a/Sources/PIALibrary/Account/Domain/UseCases/ClientStatusUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/ClientStatusUseCase.swift
@@ -1,0 +1,63 @@
+
+import Foundation
+
+public protocol ClientStatusUseCaseType {
+    typealias Completion = ((Result<ClientStatusInformation?, NetworkRequestError>) -> Void)
+    
+    func callAsFunction(completion: @escaping Completion)
+}
+
+
+class ClientStatusUseCase: ClientStatusUseCaseType {
+    
+    private let networkClient: NetworkRequestClientType
+    private let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
+    private let clientStatusDecoder: ClientStatusInformationDecoderType
+    
+    init(networkClient: NetworkRequestClientType, refreshAuthTokensChecker: RefreshAuthTokensCheckerType, clientStatusDecoder: ClientStatusInformationDecoderType) {
+        self.networkClient = networkClient
+        self.refreshAuthTokensChecker = refreshAuthTokensChecker
+        self.clientStatusDecoder = clientStatusDecoder
+    }
+    
+    func callAsFunction(completion: @escaping Completion) {
+        
+        refreshAuthTokensChecker.refreshIfNeeded { _ in }
+        
+        // No matter if refreshing the tokens fail or not,
+        // we always execute the Client Status request
+        // This request could be executed when the user is authenticated
+        // as well as when the user is NOT authenticated so it is compatible to
+        // be executed in parallel with the `refreshIfNeeded`
+        self.executeClientStatusRequest(with: completion)
+        
+    }
+    
+}
+
+
+private extension ClientStatusUseCase {
+    func executeClientStatusRequest(with completion: @escaping Completion) {
+        
+        let configuration = ClientStatusRequestConfiguration()
+        networkClient.executeRequest(with: configuration) { error, response in
+            
+            if let error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let respData = response?.data else {
+                completion(.failure(.noDataContent))
+                return
+            }
+            
+            guard let clientStatusInfo = self.clientStatusDecoder.decodeClientStatus(from: respData) else {
+                completion(.failure(.unableToDecodeData))
+                return
+            }
+            
+            completion(.success(clientStatusInfo))
+        }
+    }
+}

--- a/Sources/PIALibrary/Common/Data/Networking/Entities/NetworkRequestError.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/Entities/NetworkRequestError.swift
@@ -14,6 +14,7 @@ public enum NetworkRequestError: Error, Equatable {
     case connectionCompletedWithNoResponse
     case badReceipt
     case unknown(message: String? = nil)
+    case unableToDecodeData
     
     func asClientError() -> ClientError {
         ClientErrorMapper.map(networkRequestError: self)

--- a/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
+++ b/Sources/PIALibrary/Common/Data/Networking/NetworkRequestClient.swift
@@ -43,6 +43,11 @@ private extension NetworkRequestClient {
     /// Serial execution of all the connections until one succeeds or completes with an error when all connection attempts fail
     func executeRecursivelyUntilSuccess(connections:  [NWHttpConnectionType], completion: @escaping NetworkRequestClientType.Completion) {
         
+        guard !connections.isEmpty else {
+            completion(.allConnectionAttemptsFailed(statusCode: nil), nil)
+            return
+        }
+        
         var remainingConnections = connections
         let nextConnection = remainingConnections.removeFirst()
         

--- a/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -127,6 +127,7 @@ class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Preferenc
 
         isCheckingConnectivity = true
         accessedWebServices.taskForConnectivityCheck { (connectivity, error) in
+    
             self.isCheckingConnectivity = false
 
             guard let connectivity = connectivity else {

--- a/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
+++ b/Sources/PIALibrary/Daemons/ConnectivityDaemon.swift
@@ -127,7 +127,6 @@ class ConnectivityDaemon: Daemon, ConfigurationAccess, DatabaseAccess, Preferenc
 
         isCheckingConnectivity = true
         accessedWebServices.taskForConnectivityCheck { (connectivity, error) in
-    
             self.isCheckingConnectivity = false
 
             guard let connectivity = connectivity else {

--- a/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
@@ -27,21 +27,42 @@ import Gloss
 extension PIAWebServices {
 
     func taskForConnectivityCheck(_ callback: ((ConnectivityStatus?, Error?) -> Void)?) {
-                
-        self.accountAPI.clientStatus { (information, errors) in
-            DispatchQueue.main.async {
-                if !errors.isEmpty {
+        
+        self.clientStatusUseCase() { result in
+            switch result {
+            case .failure(let error):
+                DispatchQueue.main.async {
                     callback?(nil, ClientError.internetUnreachable)
-                    return
                 }
+            case .success(let statusInfo):
+                if let information = statusInfo {
+                    DispatchQueue.main.async {
+                        callback?(ConnectivityStatus(ipAddress: information.ip, isVPN: information.connected), nil)
+                    }
 
-                if let information = information {
-                    callback?(ConnectivityStatus(ipAddress: information.ip, isVPN: information.connected), nil)
                 } else {
-                    callback?(nil, ClientError.malformedResponseData)
+                    DispatchQueue.main.async {
+                        callback?(nil, ClientError.malformedResponseData)
+                    }
+
                 }
             }
         }
+                
+//        self.accountAPI.clientStatus { (information, errors) in
+//            DispatchQueue.main.async {
+//                if !errors.isEmpty {
+//                    callback?(nil, ClientError.internetUnreachable)
+//                    return
+//                }
+//
+//                if let information = information {
+//                    callback?(ConnectivityStatus(ipAddress: information.ip, isVPN: information.connected), nil)
+//                } else {
+//                    callback?(nil, ClientError.malformedResponseData)
+//                }
+//            }
+//        }
         
     }
     

--- a/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices+Ephemeral.swift
@@ -48,21 +48,6 @@ extension PIAWebServices {
                 }
             }
         }
-                
-//        self.accountAPI.clientStatus { (information, errors) in
-//            DispatchQueue.main.async {
-//                if !errors.isEmpty {
-//                    callback?(nil, ClientError.internetUnreachable)
-//                    return
-//                }
-//
-//                if let information = information {
-//                    callback?(ConnectivityStatus(ipAddress: information.ip, isVPN: information.connected), nil)
-//                } else {
-//                    callback?(nil, ClientError.malformedResponseData)
-//                }
-//            }
-//        }
         
     }
     

--- a/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -40,9 +40,11 @@ class PIAWebServices: WebServices, ConfigurationAccess {
     let accountAPI: IOSAccountAPI!
     let csiAPI: CSIAPI!
     let csiProtocolInformationProvider = PIACSIProtocolInformationProvider()
+    let clientStatusUseCase: ClientStatusUseCaseType
     
     
     init() {
+        self.clientStatusUseCase = AccountFactory.makeClientStatusUseCase()
         let rsa4096Certificate = Client.configuration.rsa4096Certificate
         let endpointsProvider: IRegionEndpointProvider = Client.environment == .staging ? PIARegionStagingClientStateProvider()
         : PIARegionClientStateProvider()

--- a/Tests/PIALibraryTests/Accounts/ClientStatusUseCaseTests.swift
+++ b/Tests/PIALibraryTests/Accounts/ClientStatusUseCaseTests.swift
@@ -1,0 +1,249 @@
+
+import XCTest
+@testable import PIALibrary
+
+class ClientStatusUseCaseTests: XCTestCase {
+    class Fixture {
+        let networkClientMock = NetworkRequestClientMock()
+        let refreshAuthTokensCheckerMock = RefreshAuthTokensCheckerMock()
+        let clientStatusDecoderMock = ClientStatusDecoderMock()
+        let clientStatusInfo = ClientStatusInformation(connected: true, ip: "111.11.11.11")
+        
+        func stubClientStatusInfoSuccessfulResponse() {
+            let response = NetworkRequestResponseMock(statusCode: 200, data: Data())
+            networkClientMock.executeRequestResponse = response
+        }
+        
+        func stubClientStatusInfoResponseWithNoData() {
+            let response = NetworkRequestResponseMock(statusCode: 200, data: nil)
+            networkClientMock.executeRequestResponse = response
+        }
+        
+        func stubClientStatusInfoResponseError(_ error: NetworkRequestError) {
+            networkClientMock.executeRequestError = error
+        }
+        
+        func stubRefreshAuthTokensError(_ error: NetworkRequestError) {
+            refreshAuthTokensCheckerMock.refreshIfNeededError = error
+        }
+        
+        func stubDecodeClientStatusInfo(as info: ClientStatusInformation?) {
+            clientStatusDecoderMock.decodeClientStatusResult = info
+        }
+        
+        
+    }
+    
+    var fixture: Fixture!
+    var sut: ClientStatusUseCase!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = ClientStatusUseCase(networkClient: fixture.networkClientMock, refreshAuthTokensChecker: fixture.refreshAuthTokensCheckerMock, clientStatusDecoder: fixture.clientStatusDecoderMock)
+    }
+    
+    func test_clientStatusInfo_when_request_succeeds() {
+        // GIVEN that the request to get the client status info succeeds
+        fixture.stubClientStatusInfoSuccessfulResponse()
+        fixture.stubDecodeClientStatusInfo(as: fixture.clientStatusInfo)
+        
+        instantiateSut()
+        
+        var capturedError: NetworkRequestError?
+        var capturedClientStatus: ClientStatusInformation?
+        let expectation = expectation(description: "client status request is executed")
+        
+        // WHEN getting the client status
+        sut.callAsFunction { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let statusInfo):
+                capturedClientStatus = statusInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the clientStatus request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.clientStatus)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND the client status info is returned
+        XCTAssertEqual(capturedClientStatus!, fixture.clientStatusInfo)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+    }
+    
+    func test_clientStatusInfo_when_request_fails() {
+        // GIVEN that the request to get the client status info fails
+        fixture.stubClientStatusInfoResponseError(.allConnectionAttemptsFailed(statusCode: 401))
+        
+        instantiateSut()
+        
+        var capturedError: NetworkRequestError?
+        var capturedClientStatus: ClientStatusInformation?
+        let expectation = expectation(description: "client status request is executed")
+        
+        // WHEN getting the client status
+        sut.callAsFunction { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let statusInfo):
+                capturedClientStatus = statusInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the clientStatus request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.clientStatus)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .allConnectionAttemptsFailed(statusCode: 401))
+        
+        // AND NO client status info is returned
+        XCTAssertNil(capturedClientStatus)
+    }
+    
+    func test_clientStatusInfo_when_request_fails_withNoData() {
+        // GIVEN that the request to get the client status returns no Data
+        fixture.stubClientStatusInfoResponseWithNoData()
+        
+        instantiateSut()
+        
+        var capturedError: NetworkRequestError?
+        var capturedClientStatus: ClientStatusInformation?
+        let expectation = expectation(description: "client status request is executed")
+        
+        // WHEN getting the client status
+        sut.callAsFunction { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let statusInfo):
+                capturedClientStatus = statusInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the clientStatus request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.clientStatus)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError, .noDataContent)
+        
+        // AND NO client status info is returned
+        XCTAssertNil(capturedClientStatus)
+    }
+    
+    func test_clientStatusInfo_when_decoding_fails() {
+        // GIVEN that the request to get the client status info succeeds
+        fixture.stubClientStatusInfoSuccessfulResponse()
+        // AND decoding the client status info fails
+        fixture.stubDecodeClientStatusInfo(as: nil)
+        
+        instantiateSut()
+        
+        var capturedError: NetworkRequestError?
+        var capturedClientStatus: ClientStatusInformation?
+        let expectation = expectation(description: "client status request is executed")
+        
+        // WHEN getting the client status
+        sut.callAsFunction { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let statusInfo):
+                capturedClientStatus = statusInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the clientStatus request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.clientStatus)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError!, .unableToDecodeData)
+        
+        // AND NO client status info is returned
+        XCTAssertNil(capturedClientStatus)
+    }
+    
+    func test_clientStatusInfo_when_refreshing_tokens_fail() {
+        // GIVEN that refreshing auth tokens request fails
+        fixture.stubRefreshAuthTokensError(.allConnectionAttemptsFailed(statusCode: 401))
+        
+        // AND GIVEN that the request to get the client status info succeeds
+        fixture.stubClientStatusInfoSuccessfulResponse()
+        fixture.stubDecodeClientStatusInfo(as: fixture.clientStatusInfo)
+        
+        instantiateSut()
+        
+        var capturedError: NetworkRequestError?
+        var capturedClientStatus: ClientStatusInformation?
+        let expectation = expectation(description: "client status request is executed")
+        
+        // WHEN getting the client status
+        sut.callAsFunction { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let statusInfo):
+                capturedClientStatus = statusInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the clientStatus request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.clientStatus)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND an error is NOT returned
+        XCTAssertNil(capturedError)
+        
+        // AND the client status info is returned
+        XCTAssertNotNil(capturedClientStatus)
+        XCTAssertEqual(capturedClientStatus!, fixture.clientStatusInfo)
+    }
+    
+}

--- a/Tests/PIALibraryTests/Accounts/Mocks/ClientStatusDecoderMock.swift
+++ b/Tests/PIALibraryTests/Accounts/Mocks/ClientStatusDecoderMock.swift
@@ -1,0 +1,16 @@
+
+
+import Foundation
+@testable import PIALibrary
+
+class ClientStatusDecoderMock: ClientStatusInformationDecoderType {
+    
+    var decodeClientStatusCalledAttempt = 0
+    var decodeClientStatusResult: ClientStatusInformation?
+    func decodeClientStatus(from data: Data) -> ClientStatusInformation? {
+        decodeClientStatusCalledAttempt += 1
+        return decodeClientStatusResult
+    }
+    
+    
+}

--- a/Tests/PIALibraryTests/Accounts/RefreshAuthTokensCheckerTests.swift
+++ b/Tests/PIALibraryTests/Accounts/RefreshAuthTokensCheckerTests.swift
@@ -68,6 +68,8 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN both tokens are refreshed
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
@@ -75,7 +77,6 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         // AND no error is returned
         XCTAssertNil(capturedError)
         
-        wait(for: [expectation], timeout: 3)
     }
     
     func testRefreshTokensWithError_WhenBothExpireIn10Days() {
@@ -97,6 +98,8 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN only the request to refresh the api token is called
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
@@ -104,7 +107,6 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         // AND an error is returned
         XCTAssertNotNil(capturedError)
         
-        wait(for: [expectation], timeout: 3)
     }
     
     
@@ -124,6 +126,8 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN the tokens don't get refreshed
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
@@ -131,7 +135,6 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         // AND no error is returned
         XCTAssertNil(capturedError)
         
-        wait(for: [expectation], timeout: 3)
     }
     
     func testRefreshTokens_WhenAPITokenIsAboutExpiring() {
@@ -151,6 +154,8 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN Only the API token is refreshed
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
@@ -158,7 +163,6 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         // AND no error is returned
         XCTAssertNil(capturedError)
         
-        wait(for: [expectation], timeout: 3)
     }
     
     func testRefreshTokens_WhenVpnTokenIsAboutExpiring() {
@@ -178,6 +182,8 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN Only the Vpn token is refreshed
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
@@ -185,7 +191,6 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         // AND no error is returned
         XCTAssertNil(capturedError)
         
-        wait(for: [expectation], timeout: 3)
     }
     
     func testRefreshTokens_WhenBothTokensHaveExpired() {
@@ -204,14 +209,14 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN both tokens are refreshed
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
         
         // AND no error is returned
         XCTAssertNil(capturedError)
-        
-        wait(for: [expectation], timeout: 3)
     }
     
     func testRefreshTokens_WhenNoneOfTheTokensAreFound() {
@@ -230,6 +235,8 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
             expectation.fulfill()
         }
         
+        wait(for: [expectation], timeout: 3)
+        
         // THEN both tokens are refreshed
         XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 1)
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 1)
@@ -237,7 +244,32 @@ class RefreshAuthTokensCheckerTests: XCTestCase {
         // AND no error is returned
         XCTAssertNil(capturedError)
         
+    }
+    
+    func test_callRefresh_when_already_refreshing() {
+
+        instantiateSut()
+        // GIVEN that API request to refresh the tokens has already been called
+        sut.isRefreshing = true
+        
+        let expectation = expectation(description: "Refresh call is finished")
+        var capturedError: NetworkRequestError? = nil
+        
+        // WHEN calling refresh if needed
+        sut.refreshIfNeeded() { error in
+            capturedError = error
+            expectation.fulfill()
+        }
+        
         wait(for: [expectation], timeout: 3)
+        
+        // THEN NONE of the tokens are refreshed again
+        XCTAssertEqual(fixture.refreshAPITokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
+
     }
     
 }


### PR DESCRIPTION
- Migration of the API `clientStatus` to Swift
- Update  `RefreshAuthTokensChecker` to only execute the refresh tokens request if there is not already a request in progress. This can happen because various UseCases call the `RefreshAuthTokenChecker` to refresh if needed before executing their requests. This update prevents executing multiple auth tokens refresh requests at the same time.