### PR TITLE
KM-4537: Migrate feature flags api to native

### DIFF
--- a/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
+++ b/Sources/PIALibrary/Account/CompositionRoot/AccountFactory.swift
@@ -44,7 +44,8 @@ public class AccountFactory {
             updateAccountUseCase: makeUpdateAccountUseCase(),
             paymentUseCase: makePaymentUseCase(),
             subscriptionsUseCase: makeSubscriptionsUseCase(),
-            deleteAccountUseCase: makeDeleteAccountUseCase()
+            deleteAccountUseCase: makeDeleteAccountUseCase(),
+            featureFlagsUseCase: makeFeatureFlagsUseCase()
         )
         
     }
@@ -68,6 +69,10 @@ public class AccountFactory {
     
     static func makeRefreshAuthTokensChecker() -> RefreshAuthTokensCheckerType {
         refreshAuthTokensCheckerShared
+    }
+    
+    static func makeFeatureFlagsUseCase() -> FeatureFlagsUseCaseType {
+        FeatureFlagsUseCase(networkClient: NetworkRequestFactory.maketNetworkRequestClient(), refreshAuthTokensChecker: makeRefreshAuthTokensChecker())
     }
     
     public static func makeClientStatusUseCase() -> ClientStatusUseCaseType {

--- a/Sources/PIALibrary/Account/Data/Networking/FeatureFlagsRequestConfiguration.swift
+++ b/Sources/PIALibrary/Account/Data/Networking/FeatureFlagsRequestConfiguration.swift
@@ -1,0 +1,23 @@
+
+import Foundation
+import NWHttpConnection
+
+struct FeatureFlagsRequestConfiguration: NetworkRequestConfigurationType {
+    
+    let networkRequestModule: NetworkRequestModule = .account
+    let path: RequestAPI.Path = .iosFeatureFlag
+    let httpMethod: NWHttpConnection.NWConnectionHTTPMethod = .get
+    let contentType: NetworkRequestContentType = .json
+    let inlcudeAuthHeaders: Bool = false
+    let urlQueryParameters: [String : String]? = nil
+    let responseDataType: NWDataResponseType = .jsonData
+    
+    var otherHeaders: [String : String]? = nil
+    var body: Data? = nil
+    
+    let timeout: TimeInterval = 10
+    let requestQueue: DispatchQueue? = DispatchQueue(label: "feature_flags_request.queue")
+}
+
+
+

--- a/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -41,9 +41,10 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
     private let paymentUseCase: PaymentUseCaseType
     private let subscriptionsUseCase: SubscriptionsUseCaseType
     private let deleteAccountUseCase: DeleteAccountUseCaseType
+    private let featureFlagsUseCase: FeatureFlagsUseCaseType
     
 
-    init(webServices: WebServices? = nil, logoutUseCase: LogoutUseCaseType, loginUseCase: LoginUseCaseType, signupUseCase: SignupUseCaseType, apiTokenProvider: APITokenProviderType, vpnTokenProvider: VpnTokenProviderType, accountDetailsUseCase: AccountDetailsUseCaseType, updateAccountUseCase: UpdateAccountUseCaseType, paymentUseCase: PaymentUseCaseType, subscriptionsUseCase: SubscriptionsUseCaseType, deleteAccountUseCase: DeleteAccountUseCaseType) {
+    init(webServices: WebServices? = nil, logoutUseCase: LogoutUseCaseType, loginUseCase: LoginUseCaseType, signupUseCase: SignupUseCaseType, apiTokenProvider: APITokenProviderType, vpnTokenProvider: VpnTokenProviderType, accountDetailsUseCase: AccountDetailsUseCaseType, updateAccountUseCase: UpdateAccountUseCaseType, paymentUseCase: PaymentUseCaseType, subscriptionsUseCase: SubscriptionsUseCaseType, deleteAccountUseCase: DeleteAccountUseCaseType, featureFlagsUseCase: FeatureFlagsUseCaseType) {
         self.logoutUseCase = logoutUseCase
         self.loginUseCase = loginUseCase
         self.signupUseCase = signupUseCase
@@ -54,6 +55,7 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
         self.paymentUseCase = paymentUseCase
         self.subscriptionsUseCase = subscriptionsUseCase
         self.deleteAccountUseCase = deleteAccountUseCase
+        self.featureFlagsUseCase = featureFlagsUseCase
         if let webServices = webServices {
             customWebServices = webServices
         } else {
@@ -437,14 +439,28 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
     }
     
     public func featureFlags(_ callback: SuccessLibraryCallback?) {
-        webServices.featureFlags { (features, nil) in
-            Client.configuration.featureFlags.removeAll()
-            if let features = features, !features.isEmpty {
-                Client.configuration.featureFlags.append(contentsOf: features)
+        featureFlagsUseCase() { result in
+            NSLog(">>> >>> DEfault account provider feature flags result: \(result)")
+            switch result {
+            case .failure(let error):
+                callback?(error.asClientError())
+            case .success(let featuresInfo):
+                Client.configuration.featureFlags.removeAll()
+                Client.configuration.featureFlags.append(contentsOf: featuresInfo.flags)
+                Macros.postNotification(Notification.Name.__AppDidFetchFeatureFlags)
+                callback?(nil)
             }
-            Macros.postNotification(Notification.Name.__AppDidFetchFeatureFlags)
-            callback?(nil)
         }
+        
+        
+//        webServices.featureFlags { (features, nil) in
+//            Client.configuration.featureFlags.removeAll()
+//            if let features = features, !features.isEmpty {
+//                Client.configuration.featureFlags.append(contentsOf: features)
+//            }
+//            Macros.postNotification(Notification.Name.__AppDidFetchFeatureFlags)
+//            callback?(nil)
+//        }
     }
     
     #if os(iOS) || os(tvOS)

--- a/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -440,7 +440,6 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
     
     public func featureFlags(_ callback: SuccessLibraryCallback?) {
         featureFlagsUseCase() { result in
-            NSLog(">>> >>> DEfault account provider feature flags result: \(result)")
             switch result {
             case .failure(let error):
                 callback?(error.asClientError())
@@ -451,16 +450,6 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
                 callback?(nil)
             }
         }
-        
-        
-//        webServices.featureFlags { (features, nil) in
-//            Client.configuration.featureFlags.removeAll()
-//            if let features = features, !features.isEmpty {
-//                Client.configuration.featureFlags.append(contentsOf: features)
-//            }
-//            Macros.postNotification(Notification.Name.__AppDidFetchFeatureFlags)
-//            callback?(nil)
-//        }
     }
     
     #if os(iOS) || os(tvOS)

--- a/Sources/PIALibrary/Account/Domain/Entities/FeatureFlagsInformation.swift
+++ b/Sources/PIALibrary/Account/Domain/Entities/FeatureFlagsInformation.swift
@@ -1,0 +1,15 @@
+
+import Foundation
+
+
+struct FeatureFlagsInformation: Codable {
+    let flags: [String]
+}
+
+extension FeatureFlagsInformation {
+    static func makeWith(data: Data) -> FeatureFlagsInformation? {
+        try? JSONDecoder().decode(FeatureFlagsInformation.self, from: data)
+    }
+}
+
+

--- a/Sources/PIALibrary/Account/Domain/UseCases/FeatureFlagsUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/FeatureFlagsUseCase.swift
@@ -1,0 +1,54 @@
+
+import Foundation
+
+
+protocol FeatureFlagsUseCaseType {
+    typealias Completion = ((Result<FeatureFlagsInformation, NetworkRequestError>) -> Void)
+    func callAsFunction(completion: @escaping Completion)
+}
+
+
+class FeatureFlagsUseCase: FeatureFlagsUseCaseType {
+    
+    let networkClient: NetworkRequestClientType
+    let refreshAuthTokensChecker: RefreshAuthTokensCheckerType
+    
+    init(networkClient: NetworkRequestClientType, refreshAuthTokensChecker: RefreshAuthTokensCheckerType) {
+        self.networkClient = networkClient
+        self.refreshAuthTokensChecker = refreshAuthTokensChecker
+    }
+    
+    func callAsFunction(completion: @escaping Completion) {
+        // The API auth token is not required in the feature flags request
+        // so refreshing the tokens can happen in parallel
+        refreshAuthTokensChecker.refreshIfNeeded { _ in }
+        
+        // Get feature flags request
+        executeRequest(with: completion)
+    }
+}
+
+private extension FeatureFlagsUseCase {
+    
+    func executeRequest(with completion: @escaping Completion) {
+        let configuration = FeatureFlagsRequestConfiguration()
+        networkClient.executeRequest(with: configuration) { error, dataResponse in
+            if let error {
+                completion(.failure(error))
+            } else {
+                guard let data = dataResponse?.data else {
+                    completion(.failure(.noDataContent))
+                    return
+                }
+                
+                guard let flagsInfo = FeatureFlagsInformation.makeWith(data: data) else {
+                    completion(.failure(.unableToDecodeData))
+                    return
+                }
+                
+                completion(.success(flagsInfo))
+            }
+        }
+    }
+    
+}

--- a/Sources/PIALibrary/WebServices/PIAWebServices.swift
+++ b/Sources/PIALibrary/WebServices/PIAWebServices.swift
@@ -295,16 +295,6 @@ class PIAWebServices: WebServices, ConfigurationAccess {
         }
     }
     
-    func featureFlags(_ callback: LibraryCallback<[String]>?) {
-        self.accountAPI.featureFlags { (info, errors) in
-            if let flags = info?.flags {
-                callback?(flags, nil)
-            } else {
-                callback?([], ClientError.malformedResponseData)
-            }
-        }
-    }
-    
     #if os(iOS) || os(tvOS)
     func signup(with request: Signup, _ callback: ((Credentials?, Error?) -> Void)?) {
         var marketingJSON = ""

--- a/Sources/PIALibrary/WebServices/WebServices.swift
+++ b/Sources/PIALibrary/WebServices/WebServices.swift
@@ -59,6 +59,5 @@ protocol WebServices: class {
     func taskForConnectivityCheck(_ callback: LibraryCallback<ConnectivityStatus>?)
 
     func submitDebugReport(_ shouldSendPersistedData: Bool, _ protocolLogs: String, _ callback: LibraryCallback<String>?)
-
-    func featureFlags(_ callback: LibraryCallback<[String]>?)
+    
 }

--- a/Tests/PIALibraryTests/Accounts/FeatureFlagsUseCaseTests.swift
+++ b/Tests/PIALibraryTests/Accounts/FeatureFlagsUseCaseTests.swift
@@ -5,10 +5,43 @@ import XCTest
 class FeatureFlagsUseCaseTests: XCTestCase {
     class Fixture {
         let networkClientMock = NetworkRequestClientMock()
-        let refreshAutTokensCheckerMock = RefreshAuthTokensCheckerMock()
+        let refreshAuthTokensCheckerMock = RefreshAuthTokensCheckerMock()
+        
+        let validFeatureFlagsJsonString = "{\"flags\": [\"feature_one\", \"feature_two\"], \"other_key\":\"other_value\"}"
+        
+        var validFeatureFlagsJsonData: Data {
+            validFeatureFlagsJsonString.data(using: .utf8)!
+        }
+        
+        let invalidFeatureFlagsJsonString = "{\"invalid_flags\": [\"feature_one\", \"feature_two\"], \"other_key\":\"other_value\"}"
+        
+        var invalidFeatureFlagsJsonData: Data {
+            invalidFeatureFlagsJsonString.data(using: .utf8)!
+        }
+        
+        func stubFeatureFlagsSuccessfullResponse() {
+            let successResponse = NetworkRequestResponseMock(statusCode: 200, data: validFeatureFlagsJsonData)
+            networkClientMock.executeRequestResponse = successResponse
+        }
+        
+        func stubFeatureFlagsResponseWithInvalidData() {
+            let successResponse = NetworkRequestResponseMock(statusCode: 200, data: invalidFeatureFlagsJsonData)
+            networkClientMock.executeRequestResponse = successResponse
+        }
+        
+        func stubFeatureFlagsResponseWithError(_ error: NetworkRequestError) {
+            networkClientMock.executeRequestError = error
+        }
+        
+        func stubRefreshAuthTokensIfNeededWithError(_ error: NetworkRequestError?) {
+            refreshAuthTokensCheckerMock.refreshIfNeededError = error
+        }
+        
+        func stubFeatureFlagsResponseWithNoData() {
+            networkClientMock.executeRequestResponse = NetworkRequestResponseMock(statusCode: 200, data: nil)
+        }
         
         
-        // TODO: Add stub methods
     }
     
     var fixture: Fixture!
@@ -24,19 +57,215 @@ class FeatureFlagsUseCaseTests: XCTestCase {
     }
     
     private func instantiateSut() {
-        sut = FeatureFlagsUseCase(networkClient: fixture.networkClientMock, refreshAuthTokensChecker: fixture.refreshAutTokensCheckerMock)
+        sut = FeatureFlagsUseCase(networkClient: fixture.networkClientMock, refreshAuthTokensChecker: fixture.refreshAuthTokensCheckerMock)
     }
     
     func test_get_feature_flags_successfully() {
+        // GIVEN that the request to get the feature flags succeeds
+        fixture.stubFeatureFlagsSuccessfullResponse()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Get feature flags request is executed")
+        
+        var capturedError: NetworkRequestError?
+        var capturedFlagsInfo: FeatureFlagsInformation?
+        
+        // WHEN executing the use case to get the feature flags
+        sut() { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let featureFlagsInfo):
+                capturedFlagsInfo = featureFlagsInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the feature flags request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.iosFeatureFlag)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND the feature flags info is returned with "feature_one" and "feature_two" enabled
+        XCTAssertNotNil(capturedFlagsInfo)
+        XCTAssertTrue(capturedFlagsInfo!.flags.count == 2)
+        XCTAssertTrue(capturedFlagsInfo!.flags.contains("feature_one"))
+        XCTAssertTrue(capturedFlagsInfo!.flags.contains("feature_two"))
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
         
     }
     
-    
     func test_get_feature_flags_when_network_error() {
+        // GIVEN that the request to get the feature flags fails
+        fixture.stubFeatureFlagsResponseWithError(.allConnectionAttemptsFailed(statusCode: 401))
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Get feature flags request is executed")
+        
+        var capturedError: NetworkRequestError?
+        var capturedFlagsInfo: FeatureFlagsInformation?
+        
+        // WHEN executing the use case to get the feature flags
+        sut() { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let featureFlagsInfo):
+                capturedFlagsInfo = featureFlagsInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the feature flags request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.iosFeatureFlag)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND no feature flags are returned
+        XCTAssertNil(capturedFlagsInfo)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        XCTAssertEqual(capturedError, .allConnectionAttemptsFailed(statusCode: 401))
+        
+    }
+    
+    func test_get_feature_flags_when_no_data_on_the_response() {
+        // GIVEN that the request to get the feature flags returns  no data in the response
+        fixture.stubFeatureFlagsResponseWithNoData()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Get feature flags request is executed")
+        
+        var capturedError: NetworkRequestError?
+        var capturedFlagsInfo: FeatureFlagsInformation?
+        
+        // WHEN executing the use case to get the feature flags
+        sut() { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let featureFlagsInfo):
+                capturedFlagsInfo = featureFlagsInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the feature flags request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.iosFeatureFlag)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND no feature flags are returned
+        XCTAssertNil(capturedFlagsInfo)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        XCTAssertEqual(capturedError, .noDataContent)
+        
+    }
+    
+    func test_get_feature_flags_when_invalid_data_on_the_response() {
+        // GIVEN that the request to get the feature flags returns invalid data in the response
+        fixture.stubFeatureFlagsResponseWithInvalidData()
+        
+        instantiateSut()
+        
+        let expectation = expectation(description: "Get feature flags request is executed")
+        
+        var capturedError: NetworkRequestError?
+        var capturedFlagsInfo: FeatureFlagsInformation?
+        
+        // WHEN executing the use case to get the feature flags
+        sut() { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let featureFlagsInfo):
+                capturedFlagsInfo = featureFlagsInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the feature flags request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.iosFeatureFlag)
+        
+        // AND the auth tokens are refreshed if needed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND no feature flags are returned
+        XCTAssertNil(capturedFlagsInfo)
+        
+        // AND an error is returned
+        XCTAssertNotNil(capturedError)
+        
+        XCTAssertEqual(capturedError, .unableToDecodeData)
         
     }
     
     func test_get_feature_flags_when_refresh_tokens_error() {
+        // GIVEN that the request to refresh the auth tokens fails
+        fixture.stubRefreshAuthTokensIfNeededWithError(.allConnectionAttemptsFailed(statusCode: 401))
+        // AND GIVEN that the request to get the feature flags succeeds
+        fixture.stubFeatureFlagsSuccessfullResponse()
         
+        instantiateSut()
+        
+        let expectation = expectation(description: "Get feature flags request is executed")
+        
+        var capturedError: NetworkRequestError?
+        var capturedFlagsInfo: FeatureFlagsInformation?
+        
+        // WHEN executing the use case to get the feature flags
+        sut() { result in
+            switch result {
+            case .failure(let error):
+                capturedError = error
+            case .success(let featureFlagsInfo):
+                capturedFlagsInfo = featureFlagsInfo
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 3)
+        
+        // THEN the feature flags request is executed
+        XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
+        XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.iosFeatureFlag)
+        
+        // AND call to refresh the auth tokens if needed is executed
+        XCTAssertEqual(fixture.refreshAuthTokensCheckerMock.refreshIfNeededCalledAttempt, 1)
+        
+        // AND the feature flags info is returned with "feature_one" and "feature_two" enabled
+        XCTAssertNotNil(capturedFlagsInfo)
+        XCTAssertTrue(capturedFlagsInfo!.flags.count == 2)
+        XCTAssertTrue(capturedFlagsInfo!.flags.contains("feature_one"))
+        XCTAssertTrue(capturedFlagsInfo!.flags.contains("feature_two"))
+        
+        // AND no error is returned
+        XCTAssertNil(capturedError)
     }
+    
 }

--- a/Tests/PIALibraryTests/Accounts/FeatureFlagsUseCaseTests.swift
+++ b/Tests/PIALibraryTests/Accounts/FeatureFlagsUseCaseTests.swift
@@ -1,0 +1,42 @@
+
+import XCTest
+@testable import PIALibrary
+
+class FeatureFlagsUseCaseTests: XCTestCase {
+    class Fixture {
+        let networkClientMock = NetworkRequestClientMock()
+        let refreshAutTokensCheckerMock = RefreshAuthTokensCheckerMock()
+        
+        
+        // TODO: Add stub methods
+    }
+    
+    var fixture: Fixture!
+    var sut: FeatureFlagsUseCase!
+    
+    override func setUp() {
+        fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        fixture = nil
+        sut = nil
+    }
+    
+    private func instantiateSut() {
+        sut = FeatureFlagsUseCase(networkClient: fixture.networkClientMock, refreshAuthTokensChecker: fixture.refreshAutTokensCheckerMock)
+    }
+    
+    func test_get_feature_flags_successfully() {
+        
+    }
+    
+    
+    func test_get_feature_flags_when_network_error() {
+        
+    }
+    
+    func test_get_feature_flags_when_refresh_tokens_error() {
+        
+    }
+}


### PR DESCRIPTION
- Migrate the feature flags network request to Swift native
- Automated tests to cover the success scenario and the posible errors returned