### PR TITLE
KM-4542: Update error thrown from failed login request

### DIFF
--- a/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -257,7 +257,7 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
         
         loginUseCase.login(with: credentials) { error in
             DispatchQueue.main.async {
-                self.handleLoginResult(error: error, credentials: credentials, notificationToSend: notificationToSend, callback: callback)
+                self.handleLoginResult(error: error?.asClientError(), credentials: credentials, notificationToSend: notificationToSend, callback: callback)
             }
         }
     }

--- a/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
+++ b/Sources/PIALibrary/Account/Domain/UseCases/LoginUseCase.swift
@@ -75,13 +75,14 @@ private extension LoginUseCase {
             
             guard let self else { return }
             
-            if let error {
-                completion(error)
+            if error != nil {
+
+                completion(.unauthorized)
             } else if let dataResponse {
                 let shouldSaveToken = configuration.path == .login
                 self.handleDataResponse(dataResponse, shouldSaveTokenFromResponse: shouldSaveToken, completion: completion)
             } else {
-                completion(NetworkRequestError.allConnectionAttemptsFailed())
+                completion(.unauthorized)
             }
         }
     }
@@ -90,7 +91,7 @@ private extension LoginUseCase {
         
         if shouldSaveTokenFromResponse {
             guard let dataResponseContent = dataResponse.data else {
-                completion(NetworkRequestError.noDataContent)
+                completion(.unauthorized)
                 return
             }
             saveAPIToken(from: dataResponseContent, completion: completion)
@@ -105,11 +106,15 @@ private extension LoginUseCase {
             try apiTokenProvider.saveAPIToken(from: data)
             // Refresh the Vpn token after successfully login
            refreshVpnTokenUseCase() { error in
-                completion(error)
+               if error != nil {
+                   completion(.unauthorized)
+               } else {
+                   completion(nil)
+               }
             }
             
         } catch {
-            completion(NetworkRequestError.unableToSaveAPIToken)
+            completion(.unauthorized)
         }
     }
 }

--- a/Tests/PIALibraryTests/Accounts/LoginUseCaseTests.swift
+++ b/Tests/PIALibraryTests/Accounts/LoginUseCaseTests.swift
@@ -145,8 +145,9 @@ class LoginUseCaseTests: XCTestCase {
         // AND the Vpn token is NOT refreshed
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
         
-        // AND an error is returned
+        // AND an 'unauthorized' error is returned
         XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError!, .unauthorized)
         
     }
     
@@ -177,8 +178,9 @@ class LoginUseCaseTests: XCTestCase {
         // AND the Vpn token is NOT refreshed
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
         
-        // AND an error is returned
+        // AND an 'unauthorized' error is returned
         XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError!, .unauthorized)
         
     }
     
@@ -244,8 +246,9 @@ class LoginUseCaseTests: XCTestCase {
         // AND the Vpn token is NOT refreshed
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
         
-        // AND an error is returned
+        // AND an 'unauthorized' error is returned
         XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError!, .unauthorized)
         
     }
     
@@ -275,8 +278,9 @@ class LoginUseCaseTests: XCTestCase {
         // AND the Vpn token is NOT refreshed
         XCTAssertEqual(fixture.refreshVpnTokenUseCaseMock.callAsFunctionCalledAttempt, 0)
         
-        // AND an error is returned
+        // AND an 'unauthorized' error is returned
         XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError!, .unauthorized)
         
     }
     
@@ -334,8 +338,9 @@ class LoginUseCaseTests: XCTestCase {
         XCTAssertEqual(fixture.networkClientMock.executeRequestCalledAttempt, 1)
         XCTAssertEqual(fixture.networkClientMock.executeRequestWithConfiguation?.path, RequestAPI.Path.loginLink)
         
-        // AND an error is returned
+        // AND an 'unauthorized' error is returned
         XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError!, .unauthorized)
         
     }
     


### PR DESCRIPTION
- Update the error thrown from the login with credentials and receipt requests