### PR TITLE
KM-4542: Execute logout without precondition failure

### DIFF
--- a/Sources/PIALibrary/Account/DefaultAccountProvider.swift
+++ b/Sources/PIALibrary/Account/DefaultAccountProvider.swift
@@ -409,14 +409,10 @@ open class DefaultAccountProvider: AccountProvider, ConfigurationAccess, Databas
         
     }
     
-    public func logout(_ callback: SuccessLibraryCallback?) {
-        guard isLoggedIn else {
-            preconditionFailure()
-        }
-        
+    public func logout(_ callback: SuccessLibraryCallback?) {        
         logoutUseCase() { [weak self] error in
-            self?.cleanDatabase()
             DispatchQueue.main.async {
+                self?.cleanDatabase()
                 Macros.postNotification(.PIAAccountDidLogout)
                 callback?(nil)
             }


### PR DESCRIPTION
- Avoid crashing the app when calling the logout API (even if the user is already not authenticated)
