### PR TITLE
KM-4856: Made ServerProviderFactory public to be used on the main target

### DIFF
--- a/Sources/PIALibrary/Server/CompositionRoot/ServerProviderFactory.swift
+++ b/Sources/PIALibrary/Server/CompositionRoot/ServerProviderFactory.swift
@@ -1,8 +1,8 @@
 
 import Foundation
 
-class ServerProviderFactory {
-    static func makeDefaultServerProvider() -> ServerProvider {
+public class ServerProviderFactory {
+    public static func makeDefaultServerProvider() -> ServerProvider {
         DefaultServerProvider(renewDedicatedIP: makeRenewDedicatedIPUseCase(),
                               getDedicatedIPs: makeGetDedicatedIPsUseCase(),
                               dedicatedIPServerMapper: makeDedicatedIPServerMapper())
@@ -13,7 +13,7 @@ class ServerProviderFactory {
                                refreshAuthTokensChecker: AccountFactory.makeRefreshAuthTokensChecker())
     }
     
-    public static func makeDedicatedIPServerMapper() -> DedicatedIPServerMapperType {
+    static func makeDedicatedIPServerMapper() -> DedicatedIPServerMapperType {
         DedicatedIPServerMapper(dedicatedIPTokenHandler: makeDedicatedIPTokenHandler())
     }
     


### PR DESCRIPTION
**Summary**
This PR exposes `ServerProviderFactory` to be used on the main target. 
